### PR TITLE
Lusas_Toolkit: Fixes #134, #150 NodesToOwnACartesianCoordinateSystem

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Elements/Line.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Line.cs
@@ -171,8 +171,22 @@ namespace BH.Adapter.Lusas
 
         public IFLine CreateLine(ICurve iCurve, IFPoint startPoint, IFPoint endPoint)
         {
-            Node startNode = new Node { Position = iCurve.IStartPoint() };
-            Node endNode = new Node { Position = iCurve.IEndPoint() };
+            Node startNode = Engine.Structure.Create.Node(
+                new Point
+                {
+                    X = iCurve.IStartPoint().X,
+                    Y = iCurve.IStartPoint().Y,
+                    Z = iCurve.IStartPoint().Z
+                });
+
+            Node endNode = Engine.Structure.Create.Node(
+                new Point
+                {
+                    X = iCurve.IEndPoint().X,
+                    Y = iCurve.IEndPoint().Y,
+                    Z = iCurve.IEndPoint().Z
+                });
+
             Bar bhomBar = new Bar { StartNode = startNode, EndNode = endNode };
             IFLine lusasLine = CreateLine(bhomBar, startPoint, endPoint);
             return lusasLine;

--- a/Lusas_Adapter/CRUD/Create/Elements/Point.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Point.cs
@@ -32,8 +32,9 @@ namespace BH.Adapter.Lusas
         public IFPoint CreatePoint(Node node)
         {
             IFPoint lusasPoint;
+            Point position = Engine.Structure.Query.Position(node);
             IFDatabaseOperations database_point = d_LusasData.createPoint(
-                node.Position.X, node.Position.Y, node.Position.Z);
+                position.X, position.Y, position.Z);
 
             lusasPoint = d_LusasData.getPointByNumber(d_LusasData.getLargestPointID());
             lusasPoint.setName("P" + node.CustomData[AdapterId].ToString());
@@ -55,7 +56,7 @@ namespace BH.Adapter.Lusas
 
         public IFPoint CreatePoint(Point point)
         {
-            Node newNode = new Node { Position = point };
+            Node newNode = Engine.Structure.Create.Node(new Point { X = point.X, Y = point.Y, Z = point.Z });
 
             int adapterID;
             if (newNode.CustomData.ContainsKey(AdapterId))

--- a/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
@@ -210,7 +210,7 @@ namespace BH.Adapter.Lusas
             lusasGeometricLine.setValue("elementType", "3D Thick Beam");
 
             List<double> dimensionList = new List<double> { bhomProfile.Height, bhomProfile.TopFlangeWidth,
-                bhomProfile.BotFlangeWidth, bhomProfile.TopFlangeWidth, bhomProfile.TopFlangeThickness,
+                bhomProfile.BotFlangeWidth, bhomProfile.TopFlangeThickness, bhomProfile.BotFlangeThickness,
             bhomProfile.WebThickness, bhomProfile.WeldSize};
             double[] dimensionArray = dimensionList.ToArray();
 

--- a/Lusas_Engine/Convert/ToBHoM/Elements/Edge.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/Edge.cs
@@ -35,19 +35,8 @@ namespace BH.Engine.Lusas
             Node startNode = GetNode(lusasLine, 0, bhomNodes);
             Node endNode = GetNode(lusasLine, 1, bhomNodes);
 
-            Point startPoint = new Point
-            {
-                X = startNode.Position.X,
-                Y = startNode.Position.Y,
-                Z = startNode.Position.Z
-            };
-
-            Point endPoint = new Point
-            {
-                X = endNode.Position.X,
-                Y = endNode.Position.Y,
-                Z = endNode.Position.Z
-            };
+            Point startPoint = Structure.Query.Position(startNode);
+            Point endPoint = Structure.Query.Position(endNode);
 
             HashSet<string> tags = new HashSet<string>(IsMemberOf(lusasLine, groupNames));
 

--- a/Lusas_Engine/Convert/ToBHoM/Elements/Node.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/Node.cs
@@ -22,6 +22,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Properties.Constraint;
 using Lusas.LPI;
@@ -42,12 +43,19 @@ namespace BH.Engine.Lusas
                 bhom6DOFConstraints.TryGetValue(supportAssignments[0], out nodeConstraint);
             }
 
-            Node bhomNode = new Node
-            {
-                Position = { X = lusasPoint.getX(), Y = lusasPoint.getY(), Z = lusasPoint.getZ() },
-                Tags = tags,
-                Constraint = nodeConstraint
-            };
+            //Node bhomNode = new Node
+            //{
+            //    Position = { X = lusasPoint.getX(), Y = lusasPoint.getY(), Z = lusasPoint.getZ() },
+            //    Tags = tags,
+            //    Constraint = nodeConstraint
+            //};
+
+            Node bhomNode = Structure.Create.Node(
+                new Point { X = lusasPoint.getX(), Y = lusasPoint.getY(), Z = lusasPoint.getZ() },
+                "", 
+                nodeConstraint);
+
+            bhomNode.Tags = tags;
 
             string adapterID = RemovePrefix(lusasPoint.getName(), "P");
             bhomNode.CustomData["Lusas_id"] = adapterID;

--- a/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
@@ -42,16 +42,16 @@ namespace BH.Engine.Lusas
             double iz = lusasAttribute.getValue("Iyy");
             double iy = lusasAttribute.getValue("Izz");
             double iw = lusasAttribute.getValue("Cw");
-            double wely = Math.Min(lusasAttribute.getValue("Syt"), lusasAttribute.getValue("Syb"));
-            double welz = Math.Min(lusasAttribute.getValue("Szt"), lusasAttribute.getValue("Szb"));
+            double wely = Math.Min(Math.Abs(lusasAttribute.getValue("Syt")), Math.Abs(lusasAttribute.getValue("Syb")));
+            double welz = Math.Min(Math.Abs(lusasAttribute.getValue("Szt")), Math.Abs(lusasAttribute.getValue("Szb")));
             double wply = lusasAttribute.getValue("Zpy");
             double wplz = lusasAttribute.getValue("Zpz");
             double centreZ = lusasAttribute.getValue("zo");
             double centreY = lusasAttribute.getValue("yo");
             double zt = lusasAttribute.getValue("zt");
-            double zb = lusasAttribute.getValue("zb");
-            double yt = lusasAttribute.getValue("yt");
-            double yb = lusasAttribute.getValue("yb");
+            double zb = Math.Abs(lusasAttribute.getValue("zb"));
+            double yt = Math.Abs(lusasAttribute.getValue("yb"));
+            double yb = lusasAttribute.getValue("yt");
             double asy = lusasAttribute.getValue("Asy");
             double asz = lusasAttribute.getValue("Asz");
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/395
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #134 

Changing the Node class in the `Structure_oM` from owning a `Point` to a `CoordinateSystem.Cartesian`.
Name for this property updated from `Position` to `Coordinates`

Fixes #150 

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

#### Changed:

- All methods affected by `Node` class property change made in https://github.com/BHoM/BHoM/pull/395 updated. No change made to any of the method interfaces
- `FabricatedISection ` `TopFlangeThickness `and `BotFlangeThickness `corrected when creating a Lusas section
- Distance from centroid (yb, zb) and elastic modulus (wely, welz) changed to absolute values when reading from Lusas