### PR TITLE
Lusas_Toolkit: Closes #151 Bar Mesh Duplication

### DIFF
--- a/Lusas_Adapter/CRUD/Create/_Create.cs
+++ b/Lusas_Adapter/CRUD/Create/_Create.cs
@@ -33,6 +33,7 @@ using BH.Engine.Geometry;
 using Lusas.LPI;
 using BH.Engine.Lusas.Object_Comparer.Equality_Comparer;
 using BH.oM.Adapters.Lusas;
+using BH.Engine.Reflection;
 
 namespace BH.Adapter.Lusas
 {
@@ -196,8 +197,16 @@ namespace BH.Adapter.Lusas
 
             if (bars.Any(x => x.CustomData.ContainsKey("Mesh")))
             {
-                var groupedBars = bars.GroupBy(m => new { m.Release, m.FEAType, MeshSettings1D = m.CustomData["Mesh"] });
+                var groupedReleases = bars.GroupBy(m => m.Release.Name);
 
+                //foreach (List<Bar> barReleases in groupedReleases)
+                //{
+                //    var groupedConstraints = barReleases.GroupBy(m => new { m.Release.EndRelease, m.Release.StartRelease });
+                //    if (groupedConstraints.Count()!=groupedReleases.Count())
+                //        Engine.Reflection.Compute.RecordWarning("Bar release names not unique, this will result in duplicate meshes");
+                //}
+
+                var groupedBars = bars.GroupBy(m => new { m.FEAType, m.Release.Name, MeshSettings1D = m.CustomData["Mesh"] });
 
                 List<Bar> distinctMeshBars = groupedBars.Select(m => m.First()).ToList();
                 List<IFMeshLine> lusasLineMesh = new List<IFMeshLine>();


### PR DESCRIPTION
### Issues addressed by this PR

Closes #151

Corrects bug of duplicating mesh when no Bar Release was provided.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Lusas_Toolkit/Lusas_Toolkit-%23155?csf=1&e=PSvuEc


### Changelog
- Fixed a bug whereby duplicate meshes (for each bar) were pushed if a bar release was not provided
