### PR TITLE
Lusas_Toolkit: Closes #156

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
@@ -30,7 +30,7 @@ namespace BH.Adapter.Lusas
     public partial class LusasAdapter
     {
         public List<IFLoadingBeamDistributed> CreateBarDistributedLoad(
-            BarVaryingDistributedLoad bhomBarDistributedLoad, IFLine[] lusasLines)
+            BarVaryingDistributedLoad bhomBarDistributedLoad, object[] lusasLines)
         {
             if (!CheckIllegalCharacters(bhomBarDistributedLoad.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/BarPointLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/BarPointLoad.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLoadingBeamPoint CreateBarPointLoad(BarPointLoad bhomBarPointLoad, IFLine[] lusasLines)
+        public IFLoadingBeamPoint CreateBarPointLoad(BarPointLoad bhomBarPointLoad, object[] lusasLines)
         {
             if (!CheckIllegalCharacters(bhomBarPointLoad.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/ConcentratedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/ConcentratedLoad.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLoadingConcentrated CreateConcentratedLoad(PointForce pointForce, IFPoint[] lusasPoints)
+        public IFLoadingConcentrated CreateConcentratedLoad(PointForce pointForce, object[] lusasPoints)
         {
             if (!CheckIllegalCharacters(pointForce.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/DistributedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/DistributedLoad.cs
@@ -28,7 +28,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLoadingGlobalDistributed CreateGlobalDistributedLine(BarUniformlyDistributedLoad distributedLoad, IFLine[] lusasLines)
+        public IFLoadingGlobalDistributed CreateGlobalDistributedLine(BarUniformlyDistributedLoad distributedLoad, object[] lusasLines)
         {
             if (!CheckIllegalCharacters(distributedLoad.Name))
             {
@@ -45,7 +45,7 @@ namespace BH.Adapter.Lusas
             return lusasGlobalDistributed;
         }
 
-        public IFLoadingGlobalDistributed CreateGlobalDistributedLoadSurface(AreaUniformalyDistributedLoad distributedLoad, IFSurface[] lusasSurfaces)
+        public IFLoadingGlobalDistributed CreateGlobalDistributedLoadSurface(AreaUniformalyDistributedLoad distributedLoad, object[] lusasSurfaces)
         {
             if (!CheckIllegalCharacters(distributedLoad.Name))
             {
@@ -63,7 +63,7 @@ namespace BH.Adapter.Lusas
             return lusasGlobalDistributed;
         }
 
-        public IFLoadingLocalDistributed CreateLocalDistributedLine(BarUniformlyDistributedLoad distributedLoad, IFLine[] lusasLines)
+        public IFLoadingLocalDistributed CreateLocalDistributedLine(BarUniformlyDistributedLoad distributedLoad, object[] lusasLines)
         {
             if (!CheckIllegalCharacters(distributedLoad.Name))
             {
@@ -81,7 +81,7 @@ namespace BH.Adapter.Lusas
             return lusasLocalDistributed;
         }
 
-        public IFLoadingLocalDistributed CreateLocalDistributedSurface(AreaUniformalyDistributedLoad distributedLoad, IFSurface[] lusasSurfaces)
+        public IFLoadingLocalDistributed CreateLocalDistributedSurface(AreaUniformalyDistributedLoad distributedLoad, object[] lusasSurfaces)
         {
             if (!CheckIllegalCharacters(distributedLoad.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/PrescribedDisplacement.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/PrescribedDisplacement.cs
@@ -29,7 +29,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFPrescribedDisplacementLoad CreatePrescribedDisplacement(PointDisplacement pointDisplacement, IFPoint[] lusasPoints)
+        public IFPrescribedDisplacementLoad CreatePrescribedDisplacement(PointDisplacement pointDisplacement, object[] lusasPoints)
         {
             if (!CheckIllegalCharacters(pointDisplacement.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/TemperatureLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/TemperatureLoad.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLoadingTemperature CreateBarTemperatureLoad(BarTemperatureLoad temperatureLoad, IFLine[] lusasLines)
+        public IFLoadingTemperature CreateBarTemperatureLoad(BarTemperatureLoad temperatureLoad, object[] lusasLines)
         {
             if (!CheckIllegalCharacters(temperatureLoad.Name))
             {
@@ -48,7 +48,7 @@ namespace BH.Adapter.Lusas
         }
 
         public IFLoadingTemperature CreateAreaTemperatureLoad(AreaTemperatureLoad temperatureLoad, 
-            IFSurface[] lusasSurfaces)
+            object[] lusasSurfaces)
         {
             if (!CheckIllegalCharacters(temperatureLoad.Name))
             {
@@ -67,7 +67,7 @@ namespace BH.Adapter.Lusas
         }
 
         public IFLoadingTemperature CreateTemperatureLoad(string lusasName, 
-            double temperatureChange, IFGeometry[] lusasGeometry, IFLoadcase assignedLoadcase)
+            double temperatureChange, object[] lusasGeometry, IFLoadcase assignedLoadcase)
         {
 
             IFLoadingTemperature lusasTemperatureLoad = null;

--- a/Lusas_Adapter/CRUD/Create/_Create.cs
+++ b/Lusas_Adapter/CRUD/Create/_Create.cs
@@ -419,7 +419,7 @@ namespace BH.Adapter.Lusas
 
             foreach (PointForce pointForce in pointForces)
             {
-                IFPoint[] assignedPoints = GetAssignedPoints(pointForce);
+                object[] assignedPoints = GetAssignedPoints(pointForce);
                 IFLoadingConcentrated lusasPointForce = CreateConcentratedLoad(pointForce, assignedPoints);
 
                 if (lusasPointForce == null)
@@ -455,7 +455,7 @@ namespace BH.Adapter.Lusas
         {
             foreach (BarUniformlyDistributedLoad barUniformlyDistributedLoad in barUniformlyDistributedLoads)
             {
-                IFLine[] assignedLines = GetAssignedLines(barUniformlyDistributedLoad);
+                object[] assignedLines = GetAssignedLines(barUniformlyDistributedLoad);
 
                 if (barUniformlyDistributedLoad.Axis == LoadAxis.Global)
                 {
@@ -488,7 +488,7 @@ namespace BH.Adapter.Lusas
         {
             foreach (AreaUniformalyDistributedLoad areaUniformlyDistributedLoad in areaUniformlyDistributedLoads)
             {
-                IFSurface[] assignedSurfaces = GetAssignedSurfaces(areaUniformlyDistributedLoad);
+                object[] assignedSurfaces = GetAssignedSurfaces(areaUniformlyDistributedLoad);
                 if (areaUniformlyDistributedLoad.Axis == LoadAxis.Global)
                 {
                     IFLoadingGlobalDistributed lusasGlobalDistributed =
@@ -520,7 +520,7 @@ namespace BH.Adapter.Lusas
         {
             foreach (BarTemperatureLoad barTemperatureLoad in barTemperatureLoads)
             {
-                IFLine[] arrayLines = GetAssignedLines(barTemperatureLoad);
+                object[] arrayLines = GetAssignedLines(barTemperatureLoad);
                 IFLoadingTemperature lusasBarTemperatureLoad =
                     CreateBarTemperatureLoad(barTemperatureLoad, arrayLines);
 
@@ -539,7 +539,7 @@ namespace BH.Adapter.Lusas
         {
             foreach (AreaTemperatureLoad areaTemperatureLoad in areaTemperatureLoads)
             {
-                IFSurface[] assignedLines = GetAssignedSurfaces(areaTemperatureLoad);
+                object[] assignedLines = GetAssignedSurfaces(areaTemperatureLoad);
                 IFLoadingTemperature lusasAreaTemperatureLoad =
                     CreateAreaTemperatureLoad(areaTemperatureLoad, assignedLines);
 
@@ -558,7 +558,7 @@ namespace BH.Adapter.Lusas
         {
             foreach (PointDisplacement pointDisplacement in pointDisplacements)
             {
-                IFPoint[] assignedPoints = GetAssignedPoints(pointDisplacement);
+                object[] assignedPoints = GetAssignedPoints(pointDisplacement);
                 IFPrescribedDisplacementLoad lusasPrescribedDisplacement =
                     CreatePrescribedDisplacement(pointDisplacement, assignedPoints);
 
@@ -578,7 +578,7 @@ namespace BH.Adapter.Lusas
 
             foreach (BarPointLoad barPointLoad in barPointLoads)
             {
-                IFLine[] assignedLines = GetAssignedLines(barPointLoad);
+                object[] assignedLines = GetAssignedLines(barPointLoad);
                 IFLoadingBeamPoint lusasGlobalDistributed =
                     CreateBarPointLoad(barPointLoad, assignedLines);
 
@@ -598,7 +598,7 @@ namespace BH.Adapter.Lusas
 
             foreach (BarVaryingDistributedLoad barDistributedLoad in barDistributedLoads)
             {
-                IFLine[] assignedBars = GetAssignedLines(barDistributedLoad);
+                object[] assignedBars = GetAssignedLines(barDistributedLoad);
                 List<IFLoadingBeamDistributed> lusasGlobalDistributed =
                     CreateBarDistributedLoad(barDistributedLoad, assignedBars);
 

--- a/Lusas_Adapter/CRUD/Private Helpers/GetAssignedObjects.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/GetAssignedObjects.cs
@@ -22,6 +22,7 @@
 
 using System.Collections.Generic;
 using BH.oM.Structure.Elements;
+using System.Linq;
 using Lusas.LPI;
 using BH.oM.Base;
 using BH.oM.Structure.Loads;
@@ -30,50 +31,29 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFPoint[] GetAssignedPoints(Load<Node> bhomLoads)
+        public object[] GetAssignedPoints(Load<Node> bhomLoads)
         {
-            List<IFPoint> assignedGeometry = new List<IFPoint>();
-            foreach (BHoMObject bhomObject in bhomLoads.Objects.Elements)
-            {
-                IFPoint lusasPoint = d_LusasData.getPointByName(
-                    "P" + bhomObject.CustomData[AdapterId].ToString());
+            string[] lusasIDs = bhomLoads.Objects.Elements.Select(x => x.CustomData[AdapterId].ToString()).ToArray();
 
-                assignedGeometry.Add(lusasPoint);
-            }
-
-            IFPoint[] arrayGeometry = assignedGeometry.ToArray();
+            object[] arrayGeometry = d_LusasData.getObjects("Point", lusasIDs);
 
             return arrayGeometry;
         }
 
-        public IFLine[] GetAssignedLines(Load<Bar> bhomLoads)
+        public object[] GetAssignedLines(Load<Bar> bhomLoads)
         {
-            List<IFLine> assignedGeometry = new List<IFLine>();
-            foreach (BHoMObject bhomObject in bhomLoads.Objects.Elements)
-            {
-                IFLine lusasLine = d_LusasData.getLineByName(
-                    "L" + bhomObject.CustomData[AdapterId].ToString());
+            string[] lusasIDs = bhomLoads.Objects.Elements.Select(x => x.CustomData[AdapterId].ToString()).ToArray();
 
-                assignedGeometry.Add(lusasLine);
-            }
-
-            IFLine[] arrayGeometry = assignedGeometry.ToArray();
+            object[] arrayGeometry = d_LusasData.getObjects("Line", lusasIDs);
 
             return arrayGeometry;
         }
 
-        public IFSurface[] GetAssignedSurfaces(Load<IAreaElement> bhomLoads)
+        public object[] GetAssignedSurfaces(Load<IAreaElement> bhomLoads)
         {
-            List<IFSurface> assignedGeometry = new List<IFSurface>();
-            foreach (BHoMObject bhomObject in bhomLoads.Objects.Elements)
-            {
-                IFSurface lusasSurface = d_LusasData.getSurfaceByName(
-                    "S" + bhomObject.CustomData[AdapterId].ToString());
+            string[] lusasIDs = bhomLoads.Objects.Elements.Select(x => x.CustomData[AdapterId].ToString()).ToArray();
 
-                assignedGeometry.Add(lusasSurface);
-            }
-
-            IFSurface[] arrayGeometry = assignedGeometry.ToArray();
+            object[] arrayGeometry = d_LusasData.getObjects("Surface", lusasIDs);
 
             return arrayGeometry;
         }

--- a/Lusas_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Bars.cs
@@ -36,47 +36,51 @@ namespace BH.Adapter.Lusas
         private List<Bar> ReadBars(List<string> ids = null)
         {
             object[] lusasLines = d_LusasData.getObjects("Line");
-
             List<Bar> bhomBars = new List<Bar>();
-            IEnumerable<Node> bhomNodesList = ReadNodes();
-            Dictionary<string, Node> bhomNodes = bhomNodesList.ToDictionary(
-                x => x.CustomData[AdapterId].ToString());
 
-            IEnumerable<Constraint4DOF> bhomSupportList = Read4DOFConstraints();
-            Dictionary<string, Constraint4DOF> bhomSupports = bhomSupportList.ToDictionary(
-                x => x.Name);
-
-            IEnumerable<Material> materialList = ReadMaterials();
-            Dictionary<string, Material> materials = materialList.ToDictionary(
-                x => x.Name.ToString());
-
-            IEnumerable<ISectionProperty> geometricList = ReadSectionProperties();
-            Dictionary<string, ISectionProperty> geometrics = geometricList.ToDictionary(
-                x => x.Name.ToString());
-
-            List<MeshSettings1D> meshList = ReadMeshSettings1D();
-            Dictionary<string, MeshSettings1D> meshes = meshList.ToDictionary(
-                x => x.Name.ToString());
-
-
-            HashSet<string> groupNames = ReadTags();
-
-            for (int i = 0; i < lusasLines.Count(); i++)
+            if(!(lusasLines.Count()==0))
             {
-                IFLine lusasLine = (IFLine)lusasLines[i];
-                Bar bhomBar = Engine.Lusas.Convert.ToBHoMBar
-                    (
-                    lusasLine,
-                    bhomNodes,
-                    bhomSupports,
-                    groupNames,
-                    materials,
-                    geometrics,
-                    meshes
-                    );
+                IEnumerable<Node> bhomNodesList = ReadNodes();
+                Dictionary<string, Node> bhomNodes = bhomNodesList.ToDictionary(
+                    x => x.CustomData[AdapterId].ToString());
 
-                bhomBars.Add(bhomBar);
+                IEnumerable<Constraint4DOF> bhomSupportList = Read4DOFConstraints();
+                Dictionary<string, Constraint4DOF> bhomSupports = bhomSupportList.ToDictionary(
+                    x => x.Name);
+
+                IEnumerable<Material> materialList = ReadMaterials();
+                Dictionary<string, Material> materials = materialList.ToDictionary(
+                    x => x.Name.ToString());
+
+                IEnumerable<ISectionProperty> geometricList = ReadSectionProperties();
+                Dictionary<string, ISectionProperty> geometrics = geometricList.ToDictionary(
+                    x => x.Name.ToString());
+
+                List<MeshSettings1D> meshList = ReadMeshSettings1D();
+                Dictionary<string, MeshSettings1D> meshes = meshList.ToDictionary(
+                    x => x.Name.ToString());
+
+
+                HashSet<string> groupNames = ReadTags();
+
+                for (int i = 0; i < lusasLines.Count(); i++)
+                {
+                    IFLine lusasLine = (IFLine)lusasLines[i];
+                    Bar bhomBar = Engine.Lusas.Convert.ToBHoMBar
+                        (
+                        lusasLine,
+                        bhomNodes,
+                        bhomSupports,
+                        groupNames,
+                        materials,
+                        geometrics,
+                        meshes
+                        );
+
+                    bhomBars.Add(bhomBar);
+                }
             }
+
             return bhomBars;
         }
     }

--- a/Lusas_Adapter/CRUD/Read/Elements/Elements.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Elements.cs
@@ -20,18 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using BH.oM.Base;
-using BH.oM.Geometry;
-using BH.oM.Structure.Elements;
-using BH.oM.Structure.Properties;
-using BH.oM.Structure.Loads;
-using BH.oM.Common.Materials;
-using Lusas.LPI;
-using BH.oM.Adapters.Lusas;
 
 namespace BH.Adapter.Lusas
 {

--- a/Lusas_Adapter/CRUD/Read/Elements/LusasPoints.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/LusasPoints.cs
@@ -40,7 +40,6 @@ namespace BH.Adapter.Lusas
         private List<IFPoint> ReadLusasPoints(List<string> ids = null)
         {
             object[] lusasPoints = d_LusasData.getObjects("Point");
-
             List<IFPoint> lusasPointList = new List<IFPoint>();
 
             for (int i = 0; i < lusasPoints.Count(); i++)

--- a/Lusas_Adapter/CRUD/Read/Elements/Nodes.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Nodes.cs
@@ -33,20 +33,24 @@ namespace BH.Adapter.Lusas
         private List<Node> ReadNodes(List<string> ids = null)
         {
             object[] lusasPoints = d_LusasData.getObjects("Point");
-
             List<Node> bhomNodes = new List<Node>();
-            HashSet<string> groupNames = ReadTags();
 
-            IEnumerable<Constraint6DOF> constraints6DOFList = Read6DOFConstraints();
-            Dictionary<string, Constraint6DOF> constraints6DOF = constraints6DOFList.ToDictionary(
-                x => x.Name.ToString());
-
-            for (int i = 0; i < lusasPoints.Count(); i++)
+            if(!(lusasPoints.Count()==0))
             {
-                IFPoint lusasPoint = (IFPoint)lusasPoints[i];
-                Node bhomNode = Engine.Lusas.Convert.ToBHoMNode(lusasPoint, groupNames, constraints6DOF);
-                bhomNodes.Add(bhomNode);
+                HashSet<string> groupNames = ReadTags();
+
+                IEnumerable<Constraint6DOF> constraints6DOFList = Read6DOFConstraints();
+                Dictionary<string, Constraint6DOF> constraints6DOF = constraints6DOFList.ToDictionary(
+                    x => x.Name.ToString());
+
+                for (int i = 0; i < lusasPoints.Count(); i++)
+                {
+                    IFPoint lusasPoint = (IFPoint)lusasPoints[i];
+                    Node bhomNode = Engine.Lusas.Convert.ToBHoMNode(lusasPoint, groupNames, constraints6DOF);
+                    bhomNodes.Add(bhomNode);
+                }
             }
+
             return bhomNodes;
         }
     }

--- a/Lusas_Adapter/CRUD/Read/Elements/PlanarPanels.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/PlanarPanels.cs
@@ -37,34 +37,37 @@ namespace BH.Adapter.Lusas
             object[] lusasSurfaces = d_LusasData.getObjects("Surface");
             List<PanelPlanar> bhomSurfaces = new List<PanelPlanar>();
 
-            IEnumerable<Edge> bhomEdgesList = ReadEdges();
-            Dictionary<string, Edge> bhomEdges = bhomEdgesList.ToDictionary(
-                x => x.CustomData[AdapterId].ToString());
-
-            HashSet<string> groupNames = ReadTags();
-            IEnumerable<Material> materialList = ReadMaterials();
-            Dictionary<string, Material> materials = materialList.ToDictionary(
-                x => x.Name.ToString());
-
-            IEnumerable<ISurfaceProperty> geometricList = Read2DProperties();
-            Dictionary<string, ISurfaceProperty> geometrics = geometricList.ToDictionary(
-                x => x.Name.ToString());
-
-            IEnumerable<Constraint4DOF> bhomSupportList = Read4DOFConstraints();
-            Dictionary<string, Constraint4DOF> bhomSupports = bhomSupportList.ToDictionary(
-                x => x.Name);
-
-            for (int i = 0; i < lusasSurfaces.Count(); i++)
+            if(!(lusasSurfaces.Count()==0))
             {
-                IFSurface lusasSurface = (IFSurface)lusasSurfaces[i];
-                PanelPlanar bhomPanel = Engine.Lusas.Convert.ToBHoMPanelPlanar(lusasSurface,
-                    bhomEdges,
-                    groupNames,
-                    geometrics,
-                    materials,
-                    bhomSupports);
+                IEnumerable<Edge> bhomEdgesList = ReadEdges();
+                Dictionary<string, Edge> bhomEdges = bhomEdgesList.ToDictionary(
+                    x => x.CustomData[AdapterId].ToString());
 
-                bhomSurfaces.Add(bhomPanel);
+                HashSet<string> groupNames = ReadTags();
+                IEnumerable<Material> materialList = ReadMaterials();
+                Dictionary<string, Material> materials = materialList.ToDictionary(
+                    x => x.Name.ToString());
+
+                IEnumerable<ISurfaceProperty> geometricList = Read2DProperties();
+                Dictionary<string, ISurfaceProperty> geometrics = geometricList.ToDictionary(
+                    x => x.Name.ToString());
+
+                IEnumerable<Constraint4DOF> bhomSupportList = Read4DOFConstraints();
+                Dictionary<string, Constraint4DOF> bhomSupports = bhomSupportList.ToDictionary(
+                    x => x.Name);
+
+                for (int i = 0; i < lusasSurfaces.Count(); i++)
+                {
+                    IFSurface lusasSurface = (IFSurface)lusasSurfaces[i];
+                    PanelPlanar bhomPanel = Engine.Lusas.Convert.ToBHoMPanelPlanar(lusasSurface,
+                        bhomEdges,
+                        groupNames,
+                        geometrics,
+                        materials,
+                        bhomSupports);
+
+                    bhomSurfaces.Add(bhomPanel);
+                }
             }
 
             return bhomSurfaces;

--- a/Lusas_Adapter/CRUD/Read/Elements/Points.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Points.cs
@@ -32,16 +32,20 @@ namespace BH.Adapter.Lusas
         private List<Point> ReadPoints(List<string> ids = null)
         {
             object[] lusasPoints = d_LusasData.getObjects("Point");
-
             List<Point> bhomPoints = new List<Point>();
-            HashSet<string> groupNames = ReadTags();
 
-            for (int i = 0; i < lusasPoints.Count(); i++)
+            if(!(lusasPoints.Count()==0))
             {
-                IFPoint lusasPoint = (IFPoint)lusasPoints[i];
-                Point bhomPoint = Engine.Lusas.Convert.ToBHoMPoint(lusasPoint, groupNames);
-                bhomPoints.Add(bhomPoint);
+                HashSet<string> groupNames = ReadTags();
+
+                for (int i = 0; i < lusasPoints.Count(); i++)
+                {
+                    IFPoint lusasPoint = (IFPoint)lusasPoints[i];
+                    Point bhomPoint = Engine.Lusas.Convert.ToBHoMPoint(lusasPoint, groupNames);
+                    bhomPoints.Add(bhomPoint);
+                }
             }
+
             return bhomPoints;
         }
     }

--- a/Lusas_Adapter/CRUD/Read/Loads/AreaUniformlyDistributedLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/AreaUniformlyDistributedLoads.cs
@@ -41,30 +41,33 @@ namespace BH.Adapter.Lusas
             object[] lusasDistributedLoads = lusasGlobalDistributedLoads.Concat(
                 lusasLocalDistributedLoads).ToArray();
 
-            List<PanelPlanar> bhomSurfaces = ReadPlanarPanels();
-            Dictionary<string, PanelPlanar> surfaceDictionary = bhomSurfaces.ToDictionary(
-                x => x.CustomData[AdapterId].ToString());
-
-            List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
-
-            for (int i = 0; i < lusasDistributedLoads.Count(); i++)
+            if(!(lusasDistributedLoads.Count()==0))
             {
-                IFLoading lusasDistributedLoad = (IFLoading)lusasDistributedLoads[i];
+                List<PanelPlanar> bhomSurfaces = ReadPlanarPanels();
+                Dictionary<string, PanelPlanar> surfaceDictionary = bhomSurfaces.ToDictionary(
+                    x => x.CustomData[AdapterId].ToString());
 
-                if (lusasDistributedLoad.getValue("type") == "Area")
+                List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
+
+                for (int i = 0; i < lusasDistributedLoads.Count(); i++)
                 {
-                    IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
-                        GetLoadAssignments(lusasDistributedLoad);
+                    IFLoading lusasDistributedLoad = (IFLoading)lusasDistributedLoads[i];
 
-                    foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                    if (lusasDistributedLoad.getValue("type") == "Area")
                     {
-                        AreaUniformalyDistributedLoad bhomBarUniformlyDistributedLoad =
-                            Engine.Lusas.Convert.ToAreaUniformallyDistributed(
-                                lusasDistributedLoad, groupedAssignment, surfaceDictionary);
+                        IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
+                            GetLoadAssignments(lusasDistributedLoad);
 
-                        List<string> analysisName = new List<string> { lusasDistributedLoad.getAttributeType() };
-                        bhomBarUniformlyDistributedLoad.Tags = new HashSet<string>(analysisName);
-                        bhomPanelUniformlyDistributedLoads.Add(bhomBarUniformlyDistributedLoad);
+                        foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                        {
+                            AreaUniformalyDistributedLoad bhomBarUniformlyDistributedLoad =
+                                Engine.Lusas.Convert.ToAreaUniformallyDistributed(
+                                    lusasDistributedLoad, groupedAssignment, surfaceDictionary);
+
+                            List<string> analysisName = new List<string> { lusasDistributedLoad.getAttributeType() };
+                            bhomBarUniformlyDistributedLoad.Tags = new HashSet<string>(analysisName);
+                            bhomPanelUniformlyDistributedLoads.Add(bhomBarUniformlyDistributedLoad);
+                        }
                     }
                 }
             }

--- a/Lusas_Adapter/CRUD/Read/Loads/BarTemperatureLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/BarTemperatureLoads.cs
@@ -35,43 +35,46 @@ namespace BH.Adapter.Lusas
             List<ILoad> bhomBarTemperatureLoads = new List<ILoad>();
             object[] lusasTemperatureLoads = d_LusasData.getAttributes("Temperature");
 
-            List<Bar> bhomBars = ReadBars();
-            Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
-                x => x.CustomData[AdapterId].ToString());
-
-            List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
-
-            for (int i = 0; i < lusasTemperatureLoads.Count(); i++)
+            if(!(lusasTemperatureLoads.Count()==0))
             {
-                IFLoading lusasTemperatureLoad = (IFLoading)lusasTemperatureLoads[i];
+                List<Bar> bhomBars = ReadBars();
+                Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
+                    x => x.CustomData[AdapterId].ToString());
 
-                IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
-                    GetLoadAssignments(lusasTemperatureLoad);
+                List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 
-                foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                for (int i = 0; i < lusasTemperatureLoads.Count(); i++)
                 {
-                    List<IFAssignment> assignments = new List<IFAssignment>();
+                    IFLoading lusasTemperatureLoad = (IFLoading)lusasTemperatureLoads[i];
 
-                    foreach (IFAssignment assignment in groupedAssignment)
+                    IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
+                        GetLoadAssignments(lusasTemperatureLoad);
+
+                    foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
                     {
-                        IFLine tryLine = assignment.getDatabaseObject() as IFLine;
+                        List<IFAssignment> assignments = new List<IFAssignment>();
 
-                        if (tryLine != null)
+                        foreach (IFAssignment assignment in groupedAssignment)
                         {
-                            assignments.Add(assignment);
+                            IFLine tryLine = assignment.getDatabaseObject() as IFLine;
+
+                            if (tryLine != null)
+                            {
+                                assignments.Add(assignment);
+                            }
                         }
-                    }
 
-                    List<string> analysisName = new List<string> { lusasTemperatureLoad.getAttributeType() };
+                        List<string> analysisName = new List<string> { lusasTemperatureLoad.getAttributeType() };
 
-                    if (assignments.Count != 0)
-                    {
-                        BarTemperatureLoad bhomBarTemperatureLoad =
-                            Engine.Lusas.Convert.ToBarTemperatureLoad(
-                                lusasTemperatureLoad, groupedAssignment, barDictionary);
+                        if (assignments.Count != 0)
+                        {
+                            BarTemperatureLoad bhomBarTemperatureLoad =
+                                Engine.Lusas.Convert.ToBarTemperatureLoad(
+                                    lusasTemperatureLoad, groupedAssignment, barDictionary);
 
-                        bhomBarTemperatureLoad.Tags = new HashSet<string>(analysisName);
-                        bhomBarTemperatureLoads.Add(bhomBarTemperatureLoad);
+                            bhomBarTemperatureLoad.Tags = new HashSet<string>(analysisName);
+                            bhomBarTemperatureLoads.Add(bhomBarTemperatureLoad);
+                        }
                     }
                 }
             }

--- a/Lusas_Adapter/CRUD/Read/Loads/BarUniformlyDistributedLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/BarUniformlyDistributedLoads.cs
@@ -39,30 +39,33 @@ namespace BH.Adapter.Lusas
             object[] lusasDistributedLoads = lusasGlobalDistributedLoads.Concat(
                 lusasLocalDistributedLoads).ToArray();
 
-            List<Bar> bhomBars = ReadBars();
-            Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
-                x => x.CustomData[AdapterId].ToString());
-
-            List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
-
-            for (int i = 0; i < lusasDistributedLoads.Count(); i++)
+            if(!(lusasDistributedLoads.Count()==0))
             {
-                IFLoading lusasDistributedLoad = (IFLoading)lusasDistributedLoads[i];
+                List<Bar> bhomBars = ReadBars();
+                Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
+                    x => x.CustomData[AdapterId].ToString());
 
-                IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases = GetLoadAssignments(
-                    lusasDistributedLoad);
+                List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 
-                if (lusasDistributedLoad.getValue("type") == "Length")
+                for (int i = 0; i < lusasDistributedLoads.Count(); i++)
                 {
-                    foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
-                    {
-                        BarUniformlyDistributedLoad bhomBarUniformlyDistributedLoad =
-                            Engine.Lusas.Convert.ToBarUniformallyDistributed(
-                                lusasDistributedLoad, groupedAssignment, barDictionary);
+                    IFLoading lusasDistributedLoad = (IFLoading)lusasDistributedLoads[i];
 
-                        List<string> analysisName = new List<string> { lusasDistributedLoad.getAttributeType() };
-                        bhomBarUniformlyDistributedLoad.Tags = new HashSet<string>(analysisName);
-                        bhomBarUniformlyDistributedLoads.Add(bhomBarUniformlyDistributedLoad);
+                    IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases = GetLoadAssignments(
+                        lusasDistributedLoad);
+
+                    if (lusasDistributedLoad.getValue("type") == "Length")
+                    {
+                        foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                        {
+                            BarUniformlyDistributedLoad bhomBarUniformlyDistributedLoad =
+                                Engine.Lusas.Convert.ToBarUniformallyDistributed(
+                                    lusasDistributedLoad, groupedAssignment, barDictionary);
+
+                            List<string> analysisName = new List<string> { lusasDistributedLoad.getAttributeType() };
+                            bhomBarUniformlyDistributedLoad.Tags = new HashSet<string>(analysisName);
+                            bhomBarUniformlyDistributedLoads.Add(bhomBarUniformlyDistributedLoad);
+                        }
                     }
                 }
             }

--- a/Lusas_Adapter/CRUD/Read/Loads/GravityLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/GravityLoads.cs
@@ -35,31 +35,34 @@ namespace BH.Adapter.Lusas
             List<ILoad> bhomGravityLoads = new List<ILoad>();
             object[] lusasBodyForces = d_LusasData.getAttributes("Body Force Load");
 
-            List<Bar> bhomBars = ReadBars();
-            List<PanelPlanar> bhomPlanarPanels = ReadPlanarPanels();
-            Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
-                x => x.CustomData[AdapterId].ToString());
-
-            Dictionary<string, PanelPlanar> panelPlanarDictionary = bhomPlanarPanels.ToDictionary(
-                x => x.CustomData[AdapterId].ToString());
-
-            List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
-
-            for (int i = 0; i < lusasBodyForces.Count(); i++)
+            if (!(lusasBodyForces.Count()==0))
             {
-                IFLoading lusasBodyForce = (IFLoading)lusasBodyForces[i];
+                List<Bar> bhomBars = ReadBars();
+                List<PanelPlanar> bhomPlanarPanels = ReadPlanarPanels();
+                Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
+                    x => x.CustomData[AdapterId].ToString());
 
-                IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
-                    GetLoadAssignments(lusasBodyForce);
+                Dictionary<string, PanelPlanar> panelPlanarDictionary = bhomPlanarPanels.ToDictionary(
+                    x => x.CustomData[AdapterId].ToString());
 
-                foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
+
+                for (int i = 0; i < lusasBodyForces.Count(); i++)
                 {
-                    List<string> analysisName = new List<string> { lusasBodyForce.getAttributeType() };
+                    IFLoading lusasBodyForce = (IFLoading)lusasBodyForces[i];
 
-                    GravityLoad bhomGravityLoad = Engine.Lusas.Convert.ToGravityLoad(
-                        lusasBodyForce, groupedAssignment, barDictionary, panelPlanarDictionary);
-                    bhomGravityLoad.Tags = new HashSet<string>(analysisName);
-                    bhomGravityLoads.Add(bhomGravityLoad);
+                    IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
+                        GetLoadAssignments(lusasBodyForce);
+
+                    foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                    {
+                        List<string> analysisName = new List<string> { lusasBodyForce.getAttributeType() };
+
+                        GravityLoad bhomGravityLoad = Engine.Lusas.Convert.ToGravityLoad(
+                            lusasBodyForce, groupedAssignment, barDictionary, panelPlanarDictionary);
+                        bhomGravityLoad.Tags = new HashSet<string>(analysisName);
+                        bhomGravityLoads.Add(bhomGravityLoad);
+                    }
                 }
             }
 

--- a/Lusas_Adapter/CRUD/Read/Loads/LoadCombinations.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/LoadCombinations.cs
@@ -32,19 +32,21 @@ namespace BH.Adapter.Lusas
         private List<LoadCombination> ReadLoadCombinations(List<string> ids = null)
         {
             List<LoadCombination> bhomLoadCombintations = new List<LoadCombination>();
-
             object[] lusasCombinations = d_LusasData.getLoadsets("Combinations");
 
-            List<Loadcase> lusasLoadcases = ReadLoadcases();
-            Dictionary<string, Loadcase> loadcaseDictionary = lusasLoadcases.ToDictionary(
-                x => x.Number.ToString());
-
-            for (int i = 0; i < lusasCombinations.Count(); i++)
+            if(!(lusasCombinations.Count()==0))
             {
-                IFBasicCombination lusasCombination = (IFBasicCombination)lusasCombinations[i];
-                LoadCombination bhomLoadCombination =
-                    Engine.Lusas.Convert.ToBHoMLoadCombination(lusasCombination, loadcaseDictionary);
-                bhomLoadCombintations.Add(bhomLoadCombination);
+                List<Loadcase> lusasLoadcases = ReadLoadcases();
+                Dictionary<string, Loadcase> loadcaseDictionary = lusasLoadcases.ToDictionary(
+                    x => x.Number.ToString());
+
+                for (int i = 0; i < lusasCombinations.Count(); i++)
+                {
+                    IFBasicCombination lusasCombination = (IFBasicCombination)lusasCombinations[i];
+                    LoadCombination bhomLoadCombination =
+                        Engine.Lusas.Convert.ToBHoMLoadCombination(lusasCombination, loadcaseDictionary);
+                    bhomLoadCombintations.Add(bhomLoadCombination);
+                }
             }
 
             return bhomLoadCombintations;

--- a/Lusas_Adapter/CRUD/Read/Loads/PointDisplacements.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/PointDisplacements.cs
@@ -35,28 +35,31 @@ namespace BH.Adapter.Lusas
             List<ILoad> bhomPointDisplacements = new List<ILoad>();
             object[] lusasPrescribedDisplacements = d_LusasData.getAttributes("Prescribed Load");
 
-            List<Node> bhomNodes = ReadNodes();
-            Dictionary<string, Node> nodeDictionary = bhomNodes.ToDictionary(
-                x => x.CustomData[AdapterId].ToString());
-
-            List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
-
-            for (int i = 0; i < lusasPrescribedDisplacements.Count(); i++)
+            if(!(lusasPrescribedDisplacements.Count()==0))
             {
-                IFLoading lusasPrescribedDisplacement = (IFLoading)lusasPrescribedDisplacements[i];
+                List<Node> bhomNodes = ReadNodes();
+                Dictionary<string, Node> nodeDictionary = bhomNodes.ToDictionary(
+                    x => x.CustomData[AdapterId].ToString());
 
-                IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
-                    GetLoadAssignments(lusasPrescribedDisplacement);
+                List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 
-                foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                for (int i = 0; i < lusasPrescribedDisplacements.Count(); i++)
                 {
-                    PointDisplacement bhomPointDisplacement =
-                        Engine.Lusas.Convert.ToPointDisplacement(
-                            lusasPrescribedDisplacement, groupedAssignment, nodeDictionary);
+                    IFLoading lusasPrescribedDisplacement = (IFLoading)lusasPrescribedDisplacements[i];
 
-                    List<string> analysisName = new List<string> { lusasPrescribedDisplacement.getAttributeType() };
-                    bhomPointDisplacement.Tags = new HashSet<string>(analysisName);
-                    bhomPointDisplacements.Add(bhomPointDisplacement);
+                    IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
+                        GetLoadAssignments(lusasPrescribedDisplacement);
+
+                    foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                    {
+                        PointDisplacement bhomPointDisplacement =
+                            Engine.Lusas.Convert.ToPointDisplacement(
+                                lusasPrescribedDisplacement, groupedAssignment, nodeDictionary);
+
+                        List<string> analysisName = new List<string> { lusasPrescribedDisplacement.getAttributeType() };
+                        bhomPointDisplacement.Tags = new HashSet<string>(analysisName);
+                        bhomPointDisplacements.Add(bhomPointDisplacement);
+                    }
                 }
             }
 

--- a/Lusas_Adapter/CRUD/Read/Loads/PointForces.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/PointForces.cs
@@ -22,6 +22,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Diagnostics;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Loads;
 using Lusas.LPI;
@@ -35,27 +36,30 @@ namespace BH.Adapter.Lusas
             List<ILoad> bhomPointForces = new List<ILoad>();
             object[] lusasConcentratedLoads = d_LusasData.getAttributes("Concentrated Load");
 
-            List<Node> bhomNodes = ReadNodes();
-            Dictionary<string, Node> nodeDictionary = bhomNodes.ToDictionary(
-                x => x.CustomData[AdapterId].ToString());
-
-            List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
-
-            for (int i = 0; i < lusasConcentratedLoads.Count(); i++)
+            if(!(lusasConcentratedLoads.Count()==0))
             {
-                IFLoading lusasConcentratedLoad = (IFLoading)lusasConcentratedLoads[i];
+                List<Node> bhomNodes = ReadNodes();
+                Dictionary<string, Node> nodeDictionary = bhomNodes.ToDictionary(
+                    x => x.CustomData[AdapterId].ToString());
 
-                IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
-                    GetLoadAssignments(lusasConcentratedLoad);
+                List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 
-                foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                for (int i = 0; i < lusasConcentratedLoads.Count(); i++)
                 {
-                    PointForce bhomPointForce = Engine.Lusas.Convert.ToPointForce(
-                        lusasConcentratedLoad, groupedAssignment, nodeDictionary
-                        );
-                    List<string> analysisName = new List<string> { lusasConcentratedLoad.getAttributeType() };
-                    bhomPointForce.Tags = new HashSet<string>(analysisName);
-                    bhomPointForces.Add(bhomPointForce);
+                    IFLoading lusasConcentratedLoad = (IFLoading)lusasConcentratedLoads[i];
+
+                    IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
+                        GetLoadAssignments(lusasConcentratedLoad);
+
+                    foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                    {
+                        PointForce bhomPointForce = Engine.Lusas.Convert.ToPointForce(
+                            lusasConcentratedLoad, groupedAssignment, nodeDictionary
+                            );
+                        List<string> analysisName = new List<string> { lusasConcentratedLoad.getAttributeType() };
+                        bhomPointForce.Tags = new HashSet<string>(analysisName);
+                        bhomPointForces.Add(bhomPointForce);
+                    }
                 }
             }
 

--- a/Lusas_Adapter/CRUD/Read/Properties/MeshSettings1D.cs
+++ b/Lusas_Adapter/CRUD/Read/Properties/MeshSettings1D.cs
@@ -32,7 +32,6 @@ namespace BH.Adapter.Lusas
         private List<MeshSettings1D> ReadMeshSettings1D(List<string> ids = null)
         {
             List<MeshSettings1D> bhomMeshSettings1Ds = new List<MeshSettings1D>();
-
             object[] lusasMesh1Ds = d_LusasData.getAttributes("Line Mesh");
 
             for (int i = 0; i < lusasMesh1Ds.Count(); i++)

--- a/Lusas_Adapter/CRUD/Read/Properties/MeshSettings2D.cs
+++ b/Lusas_Adapter/CRUD/Read/Properties/MeshSettings2D.cs
@@ -32,7 +32,6 @@ namespace BH.Adapter.Lusas
         private List<MeshSettings2D> ReadMeshSettings2D(List<string> ids = null)
         {
             List<MeshSettings2D> bhomMeshSettings2Ds = new List<MeshSettings2D>();
-
             object[] lusasMesh2Ds = d_LusasData.getAttributes("Surface Mesh");
 
             for (int i = 0; i < lusasMesh2Ds.Count(); i++)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #156 

<!-- Add short description of what has been fixed -->
Unnecessary reading of elements when no loads or properties existed. For script provided there was a 53.9% saving at runtime, this is likely to increase for larger models.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EuPQj7ngajRMtD5kXd2nBHABlKy80jLvvnl9O5EmNKmgVQ?e=FAQUfh

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Fixed a bug where unnecessary `Read() ` methods were invoked when loads, properties and elements did not exist.

