### PR TITLE
Lusas_Toolkit: Closes #158 #159 Runtime speed improvements

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Elements/Line.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Line.cs
@@ -79,11 +79,10 @@ namespace BH.Adapter.Lusas
                 barLocalAxis.assignTo(lusasLine);
             }
 
-            IFAssignment meshAssignment = m_LusasApplication.newAssignment();
-            meshAssignment.setAllDefaults();
-
             if (bar.CustomData.ContainsKey("Mesh"))
             {
+                IFAssignment meshAssignment = m_LusasApplication.newAssignment();
+                meshAssignment.setAllDefaults();
                 if (bar.OrientationAngle != 0 && bar.FEAType == BarFEAType.Axial)
                 {
                     Engine.Reflection.Compute.RecordWarning(

--- a/Lusas_Adapter/CRUD/Private Helpers/RuntimeReduction.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/RuntimeReduction.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+namespace BH.Adapter.Lusas
+{
+    public partial class LusasAdapter
+    {
+        public void ReduceRuntime(bool active)
+        {
+            if(active)
+            {
+                m_LusasApplication.enableUI(false);
+                m_LusasApplication.enableTrees(false);
+                m_LusasApplication.suppressMessages(0);
+                m_LusasApplication.setManualRefresh(true);
+                d_LusasData.beginCommandBatch("label", "undoable");
+            }
+            else
+            {
+                d_LusasData.closeCommandBatch();
+                m_LusasApplication.enableTrees(true);
+                m_LusasApplication.enableUI(true);
+                m_LusasApplication.suppressMessages(0);
+                m_LusasApplication.setManualRefresh(false);
+                m_LusasApplication.updateAllViews();
+            }
+        }
+    }
+}

--- a/Lusas_Adapter/CRUD/Private Helpers/RuntimeReduction.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/RuntimeReduction.cs
@@ -30,7 +30,7 @@ namespace BH.Adapter.Lusas
             {
                 m_LusasApplication.enableUI(false);
                 m_LusasApplication.enableTrees(false);
-                m_LusasApplication.suppressMessages(0);
+                m_LusasApplication.suppressMessages(1);
                 m_LusasApplication.setManualRefresh(true);
                 d_LusasData.beginCommandBatch("label", "undoable");
             }

--- a/Lusas_Adapter/Lusas_Adapter.csproj
+++ b/Lusas_Adapter/Lusas_Adapter.csproj
@@ -156,6 +156,7 @@
     <Compile Include="CRUD\Private Helpers\GetLoadAssignments.cs" />
     <Compile Include="CRUD\Private Helpers\NameSearch.cs" />
     <Compile Include="CRUD\Private Helpers\CheckIllegalCharacters.cs" />
+    <Compile Include="CRUD\Private Helpers\RuntimeReduction.cs" />
     <Compile Include="CRUD\Private Helpers\SetElementType.cs" />
     <Compile Include="CRUD\Private Helpers\SetEndConditions.cs" />
     <Compile Include="CRUD\Private Helpers\SetSplitMethod.cs" />

--- a/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
@@ -33,7 +33,7 @@ namespace BH.Engine.Lusas
         {
             string attributeName = GetName(lusasAttribute);
 
-            IProfile sectionProfile = createProfile(lusasAttribute);
+            IProfile sectionProfile = CreateProfile(lusasAttribute);
 
             double area = lusasAttribute.getValue("A");
             double rgy = lusasAttribute.getValue("ky");
@@ -68,7 +68,7 @@ namespace BH.Engine.Lusas
             return bhomSection;
         }
 
-        public static IProfile createProfile(IFAttribute lusasAttribute)
+        public static IProfile CreateProfile(IFAttribute lusasAttribute)
         {
             int sectionType = lusasAttribute.getValue("Type");
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #158 
Closes #159

<!-- Add short description of what has been fixed -->
Uses COM calls to disable Lusas modeller functionality e.g. UI, tree freshes, view refresh and message supression.
Capitalises createProfile method in some instances.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/ElhPJ0PoWAFEpWx8roRU6HIBIZB4GegE12giukI2F4NF3g?e=bxfGsY

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Improves runtime performance by disabling Lusas UI functionality (e.g. UI, TreeView, AutoRefresh and MessageSupression) during pushing.

### Additional comments
<!-- As required -->
@ChrisSelf2 please test the attached script with the master branch and this branch and see if there is a difference, in a larger script I was getting 11 minutes (master) vs 6 minutes (PR) and I want to see if this can be replicated in isolation. 