### PR TITLE
Lusas_Toolkit: Closes #53 Closes #180 Read NodeReaction + BarForce

### DIFF
--- a/Lusas_Adapter/CRUD/Private Helpers/GetFeatureResults.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/GetFeatureResults.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        internal Dictionary<string, double> GetFeatureResults(List<string> components, Dictionary<string, IFResultsComponentSet> resultsSets, IFUnitSet unitSet, int midasCivil_Id)
+        internal Dictionary<string, double> GetFeatureResults(List<string> components, Dictionary<string, IFResultsComponentSet> resultsSets, IFUnitSet unitSet, int id, string suffix)
         {
             bool validResults = true;
 
@@ -43,7 +43,16 @@ namespace BH.Adapter.Lusas
                 int nodeID = 0;
                 int nullID = 0; //For Nodal results the pLocnIndex2 will return 2 from getFeatureResults
 
-                double featureResult = resultsSet.getFeatureResults(resultsSet.getComponentNumber(component), d_LusasData.getPointByName("P" + midasCivil_Id), 3, unitSet, nodeID, nullID);
+                double featureResult = 0;
+
+                if(suffix == "P")
+                {
+                    featureResult = resultsSet.getFeatureResults(resultsSet.getComponentNumber(component), d_LusasData.getPointByName(suffix + id), 3, unitSet, nodeID, nullID);
+                }
+                else if(suffix == "L")
+                {
+                    featureResult = resultsSet.getFeatureResults(resultsSet.getComponentNumber(component), d_LusasData.getLineByName(suffix + id), 3, unitSet, nodeID, nullID);
+                }
 
                 if (featureResult == double.MinValue)
                 {
@@ -61,7 +70,7 @@ namespace BH.Adapter.Lusas
 
             if (!validResults)
             {
-                Engine.Reflection.Compute.RecordWarning("Node " + midasCivil_Id + " is not assigned a support and therefore has no valid results for NodeReaction. All values are therefore set to 0");
+                Engine.Reflection.Compute.RecordWarning(suffix + id + " is not does not have any valid results. All values are therefore set to 0");
             }
 
             return featureResults;

--- a/Lusas_Adapter/CRUD/Private Helpers/GetFeatureResults.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/GetFeatureResults.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using Lusas.LPI;
+
+namespace BH.Adapter.Lusas
+{
+    public partial class LusasAdapter
+    {
+        internal Dictionary<string, double> GetFeatureResults(List<string> components, Dictionary<string, IFResultsComponentSet> resultsSets, IFUnitSet unitSet, int midasCivil_Id)
+        {
+            bool validResults = true;
+
+            Dictionary<string, double> featureResults = new Dictionary<string, double>();
+            IFResultsComponentSet resultsSet = null;
+
+            foreach (string component in components)
+            {
+                resultsSets.TryGetValue(component, out resultsSet);
+
+                int componentNumber = resultsSet.getComponentNumber(component);
+
+                int nodeID = 0;
+                int nullID = 0; //For Nodal results the pLocnIndex2 will return 2 from getFeatureResults
+
+                double featureResult = resultsSet.getFeatureResults(resultsSet.getComponentNumber(component), d_LusasData.getPointByName("P" + midasCivil_Id), 3, unitSet, nodeID, nullID);
+
+                if (featureResult == double.MinValue)
+                {
+                    featureResult = 0;
+                }
+
+                if (!(resultsSet.isValidValue(featureResult)))
+                {
+                    validResults = false;
+                    featureResult = 0;
+                }
+
+                featureResults.Add(component, featureResult);
+            }
+
+            if (!validResults)
+            {
+                Engine.Reflection.Compute.RecordWarning("Node " + midasCivil_Id + " is not assigned a support and therefore has no valid results for NodeReaction. All values are therefore set to 0");
+            }
+
+            return featureResults;
+        }
+
+    }
+}

--- a/Lusas_Adapter/CRUD/Private Helpers/GetResultsSets.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/GetResultsSets.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using Lusas.LPI;
+
+namespace BH.Adapter.Lusas
+{
+    public partial class LusasAdapter
+    {
+        internal Dictionary<string, IFResultsComponentSet> GetResultsSets(string entity, List<string> components, string location, IFResultsContext resultsContext)
+        {
+            Dictionary<string, IFResultsComponentSet> resultsSet = new Dictionary<string, IFResultsComponentSet>();
+
+            foreach (string component in components)
+            {
+                resultsSet.Add(component, d_LusasData.getResultsComponentSet(entity, component, location, resultsContext));
+            }
+
+            return resultsSet;
+        }
+    }
+}

--- a/Lusas_Adapter/CRUD/Read/Results/BarForce.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/BarForce.cs
@@ -48,9 +48,6 @@ namespace BH.Adapter.Lusas
                 loadcaseIds = Engine.Lusas.Query.GetLoadcaseIDs(cases);
 
             IFView view = m_LusasApplication.getCurrentView();
-
-            m_LusasApplication.getVisibleSet().add("All");
-
             IFResultsContext resultsContext = m_LusasApplication.newResultsContext(view);
 
             string entity = "Force/Moment - Thick 3D Beam";

--- a/Lusas_Adapter/CRUD/Read/Results/BarForce.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/BarForce.cs
@@ -48,6 +48,9 @@ namespace BH.Adapter.Lusas
                 loadcaseIds = Engine.Lusas.Query.GetLoadcaseIDs(cases);
 
             IFView view = m_LusasApplication.getCurrentView();
+
+            m_LusasApplication.getVisibleSet().add("All");
+
             IFResultsContext resultsContext = m_LusasApplication.newResultsContext(view);
 
             string entity = "Force/Moment - Thick 3D Beam";

--- a/Lusas_Adapter/CRUD/Read/Results/NodeReaction.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/NodeReaction.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections;
+using System.Collections.Generic;
+using BH.oM.Structure.Results;
+using Lusas.LPI;
+
+namespace BH.Adapter.Lusas
+{
+    public partial class LusasAdapter
+    {
+        private List<NodeReaction> ReadNodeReaction(IList ids = null, IList cases = null)
+        {
+            List<NodeReaction> bhomNodeReactions = new List<NodeReaction>();
+
+            List<int> nodeIds = new List<int>();
+
+            if (ids == null || ids.Count == 0)
+                Engine.Reflection.Compute.RecordWarning("Please provide ids");
+            else
+                nodeIds = Engine.Lusas.Query.GetObjectIDs(ids);
+
+            List<int> loadcaseIds = new List<int>();
+
+            if (cases == null || cases.Count == 0)
+                Engine.Reflection.Compute.RecordWarning("Please provide loadcase ids");
+            else
+                loadcaseIds = Engine.Lusas.Query.GetLoadcaseIDs(cases);
+
+            IFView view = m_LusasApplication.getCurrentView();
+            IFResultsContext resultsContext = m_LusasApplication.newResultsContext(view);
+
+            string entity = "Reaction";
+            string location = "Nodal";
+
+            foreach (int loadcaseId in loadcaseIds)
+            {
+                IFLoadset loadset = d_LusasData.getLoadset(loadcaseId);
+
+                if (!loadset.needsAssociatedValues())
+                {
+                    resultsContext.setActiveLoadset(loadset);
+                }
+
+                IFUnitSet unitSet = d_LusasData.getModelUnits();
+                double forceSIConversion = 1/unitSet.getForceFactor();
+                double lengthSIConversion = 1 / unitSet.getLengthFactor();
+
+                List<string> components = new List<string>() {"Fx", "Fy", "Fz", "Mx", "My", "Mz" };
+                d_LusasData.startUsingScriptedResults();
+
+                Dictionary<string, IFResultsComponentSet> resultsSets = GetResultsSets(entity, components, location, resultsContext);
+
+                foreach (int nodeId in nodeIds)
+                {
+                    string pointName = "P" + nodeId;
+
+                    Dictionary<string, double> featureResults = GetFeatureResults(components, resultsSets, unitSet, nodeId);
+
+                    double Fx = 0; double Fy = 0; double Fz = 0; double Mx = 0; double My = 0; double Mz = 0;
+                    featureResults.TryGetValue("Fx", out Fx); featureResults.TryGetValue("Fy", out Fy); featureResults.TryGetValue("Fz", out Fz);
+                    featureResults.TryGetValue("Mx", out Mx); featureResults.TryGetValue("My", out My); featureResults.TryGetValue("Mz", out Mz);
+
+                    NodeReaction nodeReaction = new NodeReaction
+                    {
+                        ResultCase = Engine.Lusas.Query.GetName(loadset.getName()),
+                        ObjectId = nodeId,
+                        FX = Fx * forceSIConversion,
+                        FY = Fy * forceSIConversion,
+                        FZ = Fz * forceSIConversion,
+                        MX = Mx * forceSIConversion * lengthSIConversion,
+                        MY = My * forceSIConversion * lengthSIConversion,
+                        MZ = Mz * forceSIConversion * lengthSIConversion,
+                    };
+
+                    bhomNodeReactions.Add(nodeReaction);
+
+                }
+
+                d_LusasData.stopUsingScriptedResults();
+                d_LusasData.flushScriptedResults();
+            }
+
+            return bhomNodeReactions;
+        }
+
+    }
+}

--- a/Lusas_Adapter/CRUD/Read/Results/NodeReaction.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/NodeReaction.cs
@@ -48,6 +48,9 @@ namespace BH.Adapter.Lusas
                 loadcaseIds = Engine.Lusas.Query.GetLoadcaseIDs(cases);
 
             IFView view = m_LusasApplication.getCurrentView();
+
+            m_LusasApplication.getVisibleSet().add("All");
+
             IFResultsContext resultsContext = m_LusasApplication.newResultsContext(view);
 
             string entity = "Reaction";

--- a/Lusas_Adapter/CRUD/Read/Results/NodeReaction.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/NodeReaction.cs
@@ -48,9 +48,6 @@ namespace BH.Adapter.Lusas
                 loadcaseIds = Engine.Lusas.Query.GetLoadcaseIDs(cases);
 
             IFView view = m_LusasApplication.getCurrentView();
-
-            m_LusasApplication.getVisibleSet().add("All");
-
             IFResultsContext resultsContext = m_LusasApplication.newResultsContext(view);
 
             string entity = "Reaction";

--- a/Lusas_Adapter/CRUD/Read/_Read.cs
+++ b/Lusas_Adapter/CRUD/Read/_Read.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using BH.oM.Base;
+using BH.oM.Common;
 using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
@@ -31,6 +32,7 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.MaterialFragments;
+using BH.oM.Structure.Results;
 using BH.oM.Adapters.Lusas;
 
 namespace BH.Adapter.Lusas
@@ -71,6 +73,15 @@ namespace BH.Adapter.Lusas
                 return ReadMeshSettings1D(ids as dynamic);
             else if (type == typeof(MeshSettings2D))
                 return ReadMeshSettings2D(ids as dynamic);
+            return null;
+        }
+
+        protected override IEnumerable<IResult> ReadResults(Type type, IList ids = null, IList cases = null, int divisions = 5)
+        {
+            if (type == typeof(BarForce))
+                return ReadBarForce(ids, cases);
+            if (type == typeof(NodeReaction))
+                return ReadNodeReaction(ids, cases);
             return null;
         }
     }

--- a/Lusas_Adapter/Lusas_Adapter.csproj
+++ b/Lusas_Adapter/Lusas_Adapter.csproj
@@ -156,6 +156,8 @@
     <Compile Include="CRUD\Private Helpers\CreateTags.cs" />
     <Compile Include="CRUD\Private Helpers\DeleteSurfaceAssignment.cs" />
     <Compile Include="CRUD\Private Helpers\GetAssignedObjects.cs" />
+    <Compile Include="CRUD\Private Helpers\GetFeatureResults.cs" />
+    <Compile Include="CRUD\Private Helpers\GetResultsSets.cs" />
     <Compile Include="CRUD\Private Helpers\NameSearch.cs" />
     <Compile Include="CRUD\Private Helpers\RuntimeReduction.cs" />
     <Compile Include="CRUD\Read\Properties\MeshSettings1D.cs" />
@@ -186,6 +188,8 @@
     <Compile Include="CRUD\Read\Elements\Points.cs" />
     <Compile Include="CRUD\Read\Properties\SectionProperties.cs" />
     <Compile Include="CRUD\Read\Properties\Tags.cs" />
+    <Compile Include="CRUD\Read\Results\BarForce.cs" />
+    <Compile Include="CRUD\Read\Results\NodeReaction.cs" />
     <Compile Include="CRUD\Read\_Read.cs" />
     <Compile Include="CRUD\Update\UpdateObjects.cs" />
     <Compile Include="Adapter\LusasAdapter.cs" />

--- a/Lusas_Engine/Lusas_Engine.csproj
+++ b/Lusas_Engine/Lusas_Engine.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Query\GetDistinct.cs" />
     <Compile Include="Query\GetFEAType.cs" />
     <Compile Include="Query\GetLoadAssignments.cs" />
+    <Compile Include="Query\GetLoadcaseIDs.cs" />
     <Compile Include="Query\GetMeshProperties.cs" />
     <Compile Include="Modify\SetConstraint.cs" />
     <Compile Include="Convert\ToBHoM\Loads\AreaTemperatureLoad.cs" />
@@ -114,6 +115,7 @@
     <Compile Include="Query\GetAssignments.cs" />
     <Compile Include="Query\GetLOF.cs" />
     <Compile Include="Query\GetName.cs" />
+    <Compile Include="Query\GetObjectIDs.cs" />
     <Compile Include="Query\IsMemberOf.cs" />
     <Compile Include="Modify\RemovePrefix.cs" />
     <Compile Include="Compute\Warnings.cs" />

--- a/Lusas_Engine/Query/GetLoadcaseIDs.cs
+++ b/Lusas_Engine/Query/GetLoadcaseIDs.cs
@@ -1,0 +1,84 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Structure.Loads;
+
+namespace BH.Engine.Lusas
+{
+    public partial class Query
+    {
+        public static List<int> GetLoadcaseIDs(IList cases)
+        {
+            List<int> caseNums = new List<int>();
+
+            if (cases is List<string>)
+                return (cases as List<string>).Select(x => int.Parse(x)).ToList();
+            else if (cases is List<int>)
+                return cases as List<int>;
+            else if (cases is List<double>)
+                return (cases as List<double>).Select(x => (int)Math.Round(x)).ToList();
+
+            else if (cases is List<Loadcase>)
+            {
+                for (int i = 0; i < cases.Count; i++)
+                {
+                    caseNums.Add(System.Convert.ToInt32((cases[i] as Loadcase).Number));
+                }
+            }
+            else if (cases is List<LoadCombination>)
+            {
+                foreach (object lComb in cases)
+                {
+                    foreach (Tuple<double, ICase> lCase in (lComb as LoadCombination).LoadCases)
+                    {
+                        caseNums.Add(System.Convert.ToInt32(lCase.Item2.Number));
+                    }
+                    caseNums.Add(System.Convert.ToInt32((lComb as LoadCombination).CustomData["Lusas_id"]));
+                }
+            }
+
+            else
+            {
+                List<int> idsOut = new List<int>();
+                foreach (object o in cases)
+                {
+                    int id;
+                    if (int.TryParse(o.ToString(), out id))
+                    {
+                        idsOut.Add(id);
+                    }
+                }
+                return idsOut;
+            }
+
+
+            return caseNums;
+        }
+
+    }
+}
+
+

--- a/Lusas_Engine/Query/GetObjectIDs.cs
+++ b/Lusas_Engine/Query/GetObjectIDs.cs
@@ -1,0 +1,69 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Base;
+
+namespace BH.Engine.Lusas
+{
+    public partial class Query
+    {
+        public static List<int> GetObjectIDs(IList ids)
+        {
+            if (ids == null)
+            {
+                return null;
+            }
+            else
+            {
+                if (ids is List<string>)
+                    return (ids as List<string>).Select(x => int.Parse(x)).ToList();
+                else if (ids is List<int>)
+                    return ids as List<int>;
+                else if (ids is List<double>)
+                    return (ids as List<double>).Select(x => (int)Math.Round(x)).ToList();
+                else
+                {
+                    List<int> idsOut = new List<int>();
+                    foreach (object o in ids)
+                    {
+                        int id;
+                        object idObj;
+                        if (int.TryParse(o.ToString(), out id))
+                        {
+                            idsOut.Add(id);
+                        }
+                        else if (o is IBHoMObject && (o as IBHoMObject).CustomData.TryGetValue("Lusas_id", out idObj) && int.TryParse(idObj.ToString(), out id))
+                            idsOut.Add(id);
+                    }
+                    return idsOut;
+                }
+            }
+        } 
+
+    }
+}
+
+


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #53 
Closes #180 

<!-- Add short description of what has been fixed -->
Functionality added to pull `NodeReaction` from Lusas. Validates valid (i.e. `Node` not assigned `Support`).
Functionality added to pull `BarForce` from Lusas, uses the 'Feature extreme' to determine the value - this because a single Line (`Bar`) in Lusas can have many internal nodes. 

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EtO44wN2iUFLl48P9dB4lBkBBGcoXYx8RQPiwSNBlEnxsQ?e=yRv4fP

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Added
- Added functionality to pull `NodeReaction` objects from Lusas. The BHoM validates the results - for example if the user tries to pull a `NodeReaction` for a node without a support a warning will be returned and a `NodeReaction` object with 0 kN/0kNm reactions.
 - Added functionality to pull `BarForce` objects from Lusas. The absolute maximum values are used determined by the end nodes of the Bar.

### Additional comments
<!-- As required -->
@alelom I have added you as a reviewer because you have Lusas installed and no one else from the Bridge team is part of the BHoM organisation.