### PR TITLE
Pull NodeDisplacements, add GeneralisedTSection warning error and reduce visibility of private helpers and other methods

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Elements/Edge.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Edge.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLine CreateEdge(Edge edge, IFPoint startPoint, IFPoint endPoint)
+        private IFLine CreateEdge(Edge edge, IFPoint startPoint, IFPoint endPoint)
         {
             IFLine lusasLine = d_LusasData.createLineByPoints(startPoint, endPoint);
             lusasLine.setName("L" + edge.CustomData[AdapterId].ToString());

--- a/Lusas_Adapter/CRUD/Create/Elements/Line.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Line.cs
@@ -31,7 +31,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLine CreateLine(Bar bar, IFMeshLine mesh)
+        private IFLine CreateLine(Bar bar, IFMeshLine mesh)
         {
             if (
                 bar.FEAType == BarFEAType.CompressionOnly ||
@@ -97,7 +97,7 @@ namespace BH.Adapter.Lusas
 
         }
 
-        public IFLine CreateLine(Bar bar, IFPoint startPoint, IFPoint endPoint)
+        private IFLine CreateLine(Bar bar, IFPoint startPoint, IFPoint endPoint)
         {
             if (
                 bar.FEAType == BarFEAType.CompressionOnly ||
@@ -155,7 +155,7 @@ namespace BH.Adapter.Lusas
             return lusasLine;
         }
 
-        public IFLine CreateLine(ICurve iCurve, IFPoint startPoint, IFPoint endPoint)
+        private IFLine CreateLine(ICurve iCurve, IFPoint startPoint, IFPoint endPoint)
         {
             Node startNode = Engine.Structure.Create.Node(
                 new Point

--- a/Lusas_Adapter/CRUD/Create/Elements/Point.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Point.cs
@@ -28,8 +28,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-
-        public IFPoint CreatePoint(Node node)
+        private IFPoint CreatePoint(Node node)
         {
             IFPoint lusasPoint;
             Point position = Engine.Structure.Query.Position(node);

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -27,8 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-
-        public IFSurface CreateSurface(Panel panel, IFLine[] lusasLines)
+        private IFSurface CreateSurface(Panel panel, IFLine[] lusasLines)
         {
             IFSurface lusasSurface;
             if (d_LusasData.existsSurfaceByName("S" + panel.CustomData[AdapterId]))

--- a/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
@@ -30,7 +30,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public List<IFLoadingBeamDistributed> CreateBarDistributedLoad(
+        private List<IFLoadingBeamDistributed> CreateBarDistributedLoad(
             BarVaryingDistributedLoad bhomBarDistributedLoad, object[] lusasLines)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(bhomBarDistributedLoad.Name))

--- a/Lusas_Adapter/CRUD/Create/Loads/BarPointLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/BarPointLoad.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLoadingBeamPoint CreateBarPointLoad(BarPointLoad bhomBarPointLoad, object[] lusasLines)
+        private IFLoadingBeamPoint CreateBarPointLoad(BarPointLoad bhomBarPointLoad, object[] lusasLines)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(bhomBarPointLoad.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/ConcentratedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/ConcentratedLoad.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLoadingConcentrated CreateConcentratedLoad(PointLoad PointLoad, object[] lusasPoints)
+        private IFLoadingConcentrated CreateConcentratedLoad(PointLoad PointLoad, object[] lusasPoints)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(PointLoad.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/DistributedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/DistributedLoad.cs
@@ -28,7 +28,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLoadingGlobalDistributed CreateGlobalDistributedLine(BarUniformlyDistributedLoad distributedLoad, object[] lusasLines)
+        private IFLoadingGlobalDistributed CreateGlobalDistributedLine(BarUniformlyDistributedLoad distributedLoad, object[] lusasLines)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(distributedLoad.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLoadingBody CreateGravityLoad(GravityLoad gravityLoad, IFGeometry[] lusasGeometry)
+        private IFLoadingBody CreateGravityLoad(GravityLoad gravityLoad, IFGeometry[] lusasGeometry)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(gravityLoad.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/LoadCombination.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/LoadCombination.cs
@@ -30,7 +30,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFBasicCombination CreateLoadCombination(LoadCombination loadCombination)
+        private IFBasicCombination CreateLoadCombination(LoadCombination loadCombination)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(loadCombination.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -28,7 +28,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLoadcase CreateLoadcase(Loadcase loadcase)
+        private IFLoadcase CreateLoadcase(Loadcase loadcase)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(loadcase.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/PrescribedDisplacement.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/PrescribedDisplacement.cs
@@ -29,7 +29,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFPrescribedDisplacementLoad CreatePrescribedDisplacement(PointDisplacement pointDisplacement, object[] lusasPoints)
+        private IFPrescribedDisplacementLoad CreatePrescribedDisplacement(PointDisplacement pointDisplacement, object[] lusasPoints)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(pointDisplacement.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/TemperatureLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/TemperatureLoad.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLoadingTemperature CreateBarTemperatureLoad(BarTemperatureLoad temperatureLoad, object[] lusasLines)
+        private IFLoadingTemperature CreateBarTemperatureLoad(BarTemperatureLoad temperatureLoad, object[] lusasLines)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(temperatureLoad.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
@@ -29,7 +29,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFAttribute CreateGeometricLine(ISectionProperty sectionProperty)
+        private IFAttribute CreateGeometricLine(ISectionProperty sectionProperty)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(sectionProperty.Name))
             {
@@ -292,6 +292,15 @@ namespace BH.Adapter.Lusas
         {
             Engine.Reflection.Compute.RecordError(
                 "GeneralisedFabricatedBoxProfile not supported in Lusas_Toolkit"
+                );
+            return null;
+        }
+
+        private IFGeometricLine CreateProfile(GeneralisedTSectionProfile bhomProfile,
+           string lusasName)
+        {
+            Engine.Reflection.Compute.RecordError(
+                "GeneralisedTSectionProfile not supported in Lusas_Toolkit"
                 );
             return null;
         }

--- a/Lusas_Adapter/CRUD/Create/Properties/GeometricSurface.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/GeometricSurface.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFAttribute CreateGeometricSurface(ISurfaceProperty surfaceProperty)
+        private IFAttribute CreateGeometricSurface(ISurfaceProperty surfaceProperty)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(surfaceProperty.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Properties/LineMesh.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/LineMesh.cs
@@ -29,7 +29,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFMeshLine CreateMeshSettings1D(MeshSettings1D meshSettings1D, BarFEAType barFEAType = BarFEAType.Flexural, BarRelease barRelease = null)
+        private IFMeshLine CreateMeshSettings1D(MeshSettings1D meshSettings1D, BarFEAType barFEAType = BarFEAType.Flexural, BarRelease barRelease = null)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(meshSettings1D.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Properties/LocalCoordinate.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/LocalCoordinate.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFLocalCoord CreateLocalCoordinate(IFLine lusasLine)
+        private IFLocalCoord CreateLocalCoordinate(IFLine lusasLine)
         {
             object lineXAxis = null;
             object lineYAxis = null;

--- a/Lusas_Adapter/CRUD/Create/Properties/Material.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Material.cs
@@ -28,7 +28,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFAttribute CreateMaterial(IMaterialFragment material)
+        private IFAttribute CreateMaterial(IMaterialFragment material)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(material.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Properties/Support.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Support.cs
@@ -30,7 +30,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFAttribute CreateSupport(Constraint6DOF constraint)
+        private IFAttribute CreateSupport(Constraint6DOF constraint)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(constraint.Name))
             {

--- a/Lusas_Adapter/CRUD/Create/Properties/SurfaceMesh.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/SurfaceMesh.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public IFMeshSurface CreateMeshSettings2D(MeshSettings2D meshSettings2D)
+        private IFMeshSurface CreateMeshSettings2D(MeshSettings2D meshSettings2D)
         {
             if (!Engine.Lusas.Query.CheckIllegalCharacters(meshSettings2D.Name))
             {

--- a/Lusas_Adapter/CRUD/Private Helpers/AssignObjectSet.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/AssignObjectSet.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public void AssignObjectSet(IFGeometry newGeometry, HashSet<string> tags)
+        internal void AssignObjectSet(IFGeometry newGeometry, HashSet<string> tags)
         {
             foreach (string tag in tags)
             {

--- a/Lusas_Adapter/CRUD/Private Helpers/CreateTags.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/CreateTags.cs
@@ -28,7 +28,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public void CreateTags(IEnumerable<IBHoMObject> bhomObject)
+        internal void CreateTags(IEnumerable<IBHoMObject> bhomObject)
         {
             List<string> objectTags = bhomObject.SelectMany(x => x.Tags).Distinct().ToList();
 

--- a/Lusas_Adapter/CRUD/Private Helpers/DeleteLineAssignment.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/DeleteLineAssignment.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public void DeleteLineAssignments(object[] lusasAttributes)
+        internal void DeleteLineAssignments(object[] lusasAttributes)
         {
             for (int i = 0; i < lusasAttributes.Count(); i++)
             {

--- a/Lusas_Adapter/CRUD/Private Helpers/DeletePointAssignment.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/DeletePointAssignment.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public void DeletePointAssignments(object[] lusasAttributes)
+        internal void DeletePointAssignments(object[] lusasAttributes)
         {
             for (int i = 0; i < lusasAttributes.Count(); i++)
             {

--- a/Lusas_Adapter/CRUD/Private Helpers/DeleteSurfaceAssignment.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/DeleteSurfaceAssignment.cs
@@ -27,7 +27,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public void DeleteSurfaceAssignments(object[] lusasAttributes)
+        internal void DeleteSurfaceAssignments(object[] lusasAttributes)
         {
             for (int i = 0; i < lusasAttributes.Count(); i++)
             {

--- a/Lusas_Adapter/CRUD/Private Helpers/GetAssignedObjects.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/GetAssignedObjects.cs
@@ -31,7 +31,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public object[] GetAssignedPoints(Load<Node> bhomLoads)
+        internal object[] GetAssignedPoints(Load<Node> bhomLoads)
         {
             string[] lusasIDs = bhomLoads.Objects.Elements.Select(x => x.CustomData[AdapterId].ToString()).ToArray();
 

--- a/Lusas_Adapter/CRUD/Private Helpers/GetResultsSets.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/GetResultsSets.cs
@@ -25,7 +25,7 @@ using Lusas.LPI;
 
 namespace BH.Adapter.Lusas
 {
-    internal partial class LusasAdapter
+    public partial class LusasAdapter
     {
         internal Dictionary<string, IFResultsComponentSet> GetResultsSets(string entity, List<string> components, string location, IFResultsContext resultsContext)
         {

--- a/Lusas_Adapter/CRUD/Private Helpers/GetResultsSets.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/GetResultsSets.cs
@@ -25,7 +25,7 @@ using Lusas.LPI;
 
 namespace BH.Adapter.Lusas
 {
-    public partial class LusasAdapter
+    internal partial class LusasAdapter
     {
         internal Dictionary<string, IFResultsComponentSet> GetResultsSets(string entity, List<string> components, string location, IFResultsContext resultsContext)
         {

--- a/Lusas_Adapter/CRUD/Private Helpers/NameSearch.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/NameSearch.cs
@@ -24,7 +24,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public  void NameSearch(string prefix, string customID, string suffix, ref string name)
+        internal void NameSearch(string prefix, string customID, string suffix, ref string name)
         {
             for (int i = 1; i < int.Parse(customID); i++)
             {

--- a/Lusas_Adapter/CRUD/Private Helpers/RuntimeReduction.cs
+++ b/Lusas_Adapter/CRUD/Private Helpers/RuntimeReduction.cs
@@ -24,7 +24,7 @@ namespace BH.Adapter.Lusas
 {
     public partial class LusasAdapter
     {
-        public void ReduceRuntime(bool active)
+        internal void ReduceRuntime(bool active)
         {
             if(active)
             {

--- a/Lusas_Adapter/CRUD/Read/Results/NodeDisplacement.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/NodeDisplacement.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections;
+using System.Collections.Generic;
+using BH.oM.Structure.Results;
+using Lusas.LPI;
+
+namespace BH.Adapter.Lusas
+{
+    public partial class LusasAdapter
+    {
+        private List<NodeDisplacement> ReadNodeDisplacement(IList ids = null, IList cases = null)
+        {
+            List<NodeDisplacement> bhomNodeDisplacements = new List<NodeDisplacement>();
+
+            List<int> nodeIds = new List<int>();
+
+            if (ids == null || ids.Count == 0)
+                Engine.Reflection.Compute.RecordWarning("Please provide ids");
+            else
+                nodeIds = Engine.Lusas.Query.GetObjectIDs(ids);
+
+            List<int> loadcaseIds = new List<int>();
+
+            if (cases == null || cases.Count == 0)
+                Engine.Reflection.Compute.RecordWarning("Please provide loadcase ids");
+            else
+                loadcaseIds = Engine.Lusas.Query.GetLoadcaseIDs(cases);
+
+            IFView view = m_LusasApplication.getCurrentView();
+            IFResultsContext resultsContext = m_LusasApplication.newResultsContext(view);
+
+            string entity = "Displacement";
+            string location = "Nodal";
+
+            foreach (int loadcaseId in loadcaseIds)
+            {
+                IFLoadset loadset = d_LusasData.getLoadset(loadcaseId);
+
+                if (!loadset.needsAssociatedValues())
+                {
+                    resultsContext.setActiveLoadset(loadset);
+                }
+
+                IFUnitSet unitSet = d_LusasData.getModelUnits();
+                double forceSIConversion = 1 / unitSet.getForceFactor();
+                double lengthSIConversion = 1 / unitSet.getLengthFactor();
+
+                List<string> components = new List<string>() { "DX", "DY", "DZ", "THX", "THY", "THZ" };
+                d_LusasData.startUsingScriptedResults();
+
+                Dictionary<string, IFResultsComponentSet> resultsSets = GetResultsSets(entity, components, location, resultsContext);
+
+                foreach (int nodeId in nodeIds)
+                {
+                    string pointName = "P" + nodeId;
+
+                    Dictionary<string, double> featureResults = GetFeatureResults(components, resultsSets, unitSet, nodeId, "P");
+
+                    double Fx = 0; double Fy = 0; double Fz = 0; double Mx = 0; double My = 0; double Mz = 0;
+                    featureResults.TryGetValue("DX", out Fx); featureResults.TryGetValue("DY", out Fy); featureResults.TryGetValue("DZ", out Fz);
+                    featureResults.TryGetValue("THX", out Mx); featureResults.TryGetValue("THY", out My); featureResults.TryGetValue("THZ", out Mz);
+
+                    NodeDisplacement bhomNodeDisplacement = new NodeDisplacement
+                    {
+                        ResultCase = Engine.Lusas.Query.GetName(loadset.getName()),
+                        ObjectId = nodeId,
+                        UX = Fx * forceSIConversion,
+                        UY = Fy * forceSIConversion,
+                        UZ = Fz * forceSIConversion,
+                        RX = Mx * forceSIConversion * lengthSIConversion,
+                        RY = My * forceSIConversion * lengthSIConversion,
+                        RZ = Mz * forceSIConversion * lengthSIConversion,
+                    };
+
+                    bhomNodeDisplacements.Add(bhomNodeDisplacement);
+
+                }
+
+                d_LusasData.stopUsingScriptedResults();
+                d_LusasData.flushScriptedResults();
+            }
+
+            return bhomNodeDisplacements;
+        }
+
+    }
+}

--- a/Lusas_Adapter/CRUD/Read/_Read.cs
+++ b/Lusas_Adapter/CRUD/Read/_Read.cs
@@ -80,6 +80,8 @@ namespace BH.Adapter.Lusas
         {
             if (type == typeof(BarForce))
                 return ReadBarForce(ids, cases);
+            if (type == typeof(NodeDisplacement))
+                return ReadNodeDisplacement(ids, cases);
             if (type == typeof(NodeReaction))
                 return ReadNodeReaction(ids, cases);
             return null;

--- a/Lusas_Adapter/Lusas_Adapter.csproj
+++ b/Lusas_Adapter/Lusas_Adapter.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -189,6 +190,7 @@
     <Compile Include="CRUD\Read\Properties\SectionProperties.cs" />
     <Compile Include="CRUD\Read\Properties\Tags.cs" />
     <Compile Include="CRUD\Read\Results\BarForce.cs" />
+    <Compile Include="CRUD\Read\Results\NodeDisplacement.cs" />
     <Compile Include="CRUD\Read\Results\NodeReaction.cs" />
     <Compile Include="CRUD\Read\_Read.cs" />
     <Compile Include="CRUD\Update\UpdateObjects.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #163 
Closes #173 
Closes #183 

<!-- Add short description of what has been fixed -->
Added functionality for pulling `NodeDisplacement `results.
Added error for `GeneralisedTSection `when pushing.

### Test files
<!-- Link to test files to validate the proposed changes -->
Pull `NodeDisplacement`:
https://burohappold.sharepoint.com/:f:/s/BHoM/EjvDhVeeIGZOjDuVa22rAncBgUnWBnz8VCQR8kdm3t0n_w?e=S1KIMU

Push GeneralisedTSection:
https://burohappold.sharepoint.com/:f:/s/BHoM/EpERuzS1UkVFtxtWZTZG1SsBVPGmdYA2Pp1bK77OqNf7nw?e=euO3oK

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `NodeDisplacement `results can now be pulled from Lusas
- Error added when trying to push `GeneralisedTSection `to Lusas as they are not supported in Lusas
- Create and PrivateHelper methods made `internal `or `private `as they are not useful in the UI