### PR TITLE
Add support for Timber, Aluminium and Generic Materials

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
@@ -72,6 +72,28 @@ namespace BH.Adapter.Lusas
             return null;
         }
 
+        private IFAttribute CreateSection(TimberSection sectionProperty, string lusasName)
+        {
+            IFAttribute lusasGeometricLine = CreateProfile(
+                sectionProperty.SectionProfile as dynamic, lusasName
+                );
+            return lusasGeometricLine;
+        }
+        private IFAttribute CreateSection(AluminiumSection sectionProperty, string lusasName)
+        {
+            IFAttribute lusasGeometricLine = CreateProfile(
+                sectionProperty.SectionProfile as dynamic, lusasName
+                );
+            return lusasGeometricLine;
+        }
+        private IFAttribute CreateSection(GenericSection sectionProperty, string lusasName)
+        {
+            IFAttribute lusasGeometricLine = CreateProfile(
+                sectionProperty.SectionProfile as dynamic, lusasName
+                );
+            return lusasGeometricLine;
+        }
+
         private IFGeometricLine CreateProfile(RectangleProfile bhomProfile, string lusasName)
         {
             IFGeometricLine lusasGeometricLine = d_LusasData.createGeometricLine(lusasName);

--- a/Lusas_Adapter/CRUD/Create/Properties/Material.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Material.cs
@@ -68,8 +68,8 @@ namespace BH.Adapter.Lusas
                     lusasMaterial.setValue("ay", iorthotropic.ThermalExpansionCoeff.Y);
                     lusasMaterial.setValue("az", iorthotropic.ThermalExpansionCoeff.Z);
 
-                    lusasMaterial.setValue("axy", System.Math.Sqrt(System.Math.Pow(iorthotropic.ThermalExpansionCoeff.X,2)) 
-                        + System.Math.Pow(iorthotropic.ThermalExpansionCoeff.Y,2));
+                    lusasMaterial.setValue("axy", System.Math.Sqrt(System.Math.Pow(iorthotropic.ThermalExpansionCoeff.X,2) 
+                        + System.Math.Pow(iorthotropic.ThermalExpansionCoeff.Y,2)));
 
                     lusasMaterial.setName(lusasName);
                 }

--- a/Lusas_Adapter/CRUD/Create/Properties/Material.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Material.cs
@@ -22,6 +22,8 @@
 
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.Structure;
+using BH.oM.Geometry;
+using BH.Engine.Geometry;
 using Lusas.LPI;
 
 namespace BH.Adapter.Lusas
@@ -68,11 +70,17 @@ namespace BH.Adapter.Lusas
 
                 else
                 {
-                    lusasMaterial = d_LusasData.createOrthotropicAxisymmetricMaterial(material.Name,
-                    iorthotropic.YoungsModulus.X, iorthotropic.YoungsModulus.Y, iorthotropic.YoungsModulus.Z,
-                    iorthotropic.ShearModulus, iorthotropic.PoissonsRatio.X, iorthotropic.PoissonsRatio.Y, iorthotropic.PoissonsRatio.Z,
-                    0, iorthotropic.Density, iorthotropic.ThermalExpansionCoeff);
-
+               
+                    lusasMaterial = d_LusasData.createOrthotropicAxisymmetricMaterial(material.Name, 
+                        iorthotropic.YoungsModulus.X, iorthotropic.YoungsModulus.Y, iorthotropic.YoungsModulus.Z,
+                        iorthotropic.ShearModulus.X, iorthotropic.PoissonsRatio.X, iorthotropic.PoissonsRatio.Y, iorthotropic.PoissonsRatio.Z,
+                        0.0, iorthotropic.Density, 0.0);
+                    lusasMaterial.setValue( "ax", iorthotropic.ThermalExpansionCoeff.X);
+                    lusasMaterial.setValue("ay", iorthotropic.ThermalExpansionCoeff.Y);
+                    lusasMaterial.setValue("az", iorthotropic.ThermalExpansionCoeff.Z);
+                    Vector ThermalExpansionCoeffxy = new Vector () { X = iorthotropic.ThermalExpansionCoeff.X, Y = iorthotropic.ThermalExpansionCoeff.Y, Z= 0 };
+                    double XY = ThermalExpansionCoeffxy.Length();
+                    lusasMaterial.setValue("axy", XY);
                     lusasMaterial.setName(lusasName);
                 }
             }

--- a/Lusas_Adapter/CRUD/Create/Properties/Material.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Material.cs
@@ -72,15 +72,16 @@ namespace BH.Adapter.Lusas
                 {
                
                     lusasMaterial = d_LusasData.createOrthotropicAxisymmetricMaterial(material.Name, 
-                    iorthotropic.YoungsModulus.X, iorthotropic.YoungsModulus.Y, iorthotropic.YoungsModulus.Z,
-                    iorthotropic.ShearModulus.X, iorthotropic.PoissonsRatio.X, iorthotropic.PoissonsRatio.Y, iorthotropic.PoissonsRatio.Z,
-                    0.0, iorthotropic.Density, 0.0);
+                        iorthotropic.YoungsModulus.X, iorthotropic.YoungsModulus.Y, iorthotropic.YoungsModulus.Z,
+                        iorthotropic.ShearModulus.X, iorthotropic.PoissonsRatio.X, iorthotropic.PoissonsRatio.Y, iorthotropic.PoissonsRatio.Z,
+                        0.0, iorthotropic.Density, 0.0);
 
                     lusasMaterial.setValue( "ax", iorthotropic.ThermalExpansionCoeff.X);
                     lusasMaterial.setValue("ay", iorthotropic.ThermalExpansionCoeff.Y);
                     lusasMaterial.setValue("az", iorthotropic.ThermalExpansionCoeff.Z);
 
-                    Vector ThermalExpansionCoeffxy = new Vector () { X = iorthotropic.ThermalExpansionCoeff.X, Y = iorthotropic.ThermalExpansionCoeff.Y, Z= 0 };
+                    Vector ThermalExpansionCoeffxy = new Vector ()
+                        { X = iorthotropic.ThermalExpansionCoeff.X, Y = iorthotropic.ThermalExpansionCoeff.Y, Z= 0 };
                     double XY = ThermalExpansionCoeffxy.Length();
                     lusasMaterial.setValue("axy", XY);
 

--- a/Lusas_Adapter/CRUD/Create/Properties/Material.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Material.cs
@@ -21,9 +21,6 @@
  */
 
 using BH.oM.Structure.MaterialFragments;
-using BH.Engine.Structure;
-using BH.oM.Geometry;
-using BH.Engine.Geometry;
 using Lusas.LPI;
 
 namespace BH.Adapter.Lusas
@@ -71,10 +68,8 @@ namespace BH.Adapter.Lusas
                     lusasMaterial.setValue("ay", iorthotropic.ThermalExpansionCoeff.Y);
                     lusasMaterial.setValue("az", iorthotropic.ThermalExpansionCoeff.Z);
 
-                    Vector ThermalExpansionCoeffxy = new Vector()
-                    { X = iorthotropic.ThermalExpansionCoeff.X, Y = iorthotropic.ThermalExpansionCoeff.Y, Z = 0 };
-                    double XY = ThermalExpansionCoeffxy.Length();
-                    lusasMaterial.setValue("axy", XY);
+                    lusasMaterial.setValue("axy", System.Math.Sqrt(System.Math.Pow(iorthotropic.ThermalExpansionCoeff.X,2)) 
+                        + System.Math.Pow(iorthotropic.ThermalExpansionCoeff.Y,2));
 
                     lusasMaterial.setName(lusasName);
                 }

--- a/Lusas_Adapter/CRUD/Create/Properties/Material.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Material.cs
@@ -38,14 +38,16 @@ namespace BH.Adapter.Lusas
             IFAttribute lusasMaterial = null;
             string lusasName = "M" + material.CustomData[AdapterIdName] + "/" + material.Name;
 
-            if(material is IIsotropic)
+            if (material is IIsotropic)
             {
                 IIsotropic isotropic = material as IIsotropic;
 
                 if (d_LusasData.existsAttribute("Material", lusasName))
                 {
+
                     lusasMaterial = d_LusasData.getAttribute("Material", lusasName);
                 }
+
                 else
                 {
                     lusasMaterial = d_LusasData.createIsotropicMaterial(material.Name,
@@ -54,14 +56,29 @@ namespace BH.Adapter.Lusas
                     lusasMaterial.setName(lusasName);
                 }
             }
-            else
+            else if (material is IOrthotropic)
             {
-                Engine.Reflection.Compute.RecordWarning("Lusas_Toolkit currently suports Isotropic materials only. No structural properties for material with name " + material.Name + " have been pushed");
-                return null; ;
-            }
+                IOrthotropic iorthotropic = material as IOrthotropic;
 
+                if (d_LusasData.existsAttribute("Material", lusasName))
+                {
+
+                    lusasMaterial = d_LusasData.getAttribute("Material", lusasName);
+                }
+
+                else
+                {
+                    lusasMaterial = d_LusasData.createOrthotropicAxisymmetricMaterial(material.Name,
+                    iorthotropic.YoungsModulus.X, iorthotropic.YoungsModulus.Y, iorthotropic.YoungsModulus.Z,
+                    iorthotropic.ShearModulus, iorthotropic.PoissonsRatio.X, iorthotropic.PoissonsRatio.Y, iorthotropic.PoissonsRatio.Z,
+                    0, iorthotropic.Density, iorthotropic.ThermalExpansionCoeff);
+
+                    lusasMaterial.setName(lusasName);
+                }
+            }
             return lusasMaterial;
         }
+
     }
 }
 

--- a/Lusas_Adapter/CRUD/Create/Properties/Material.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Material.cs
@@ -39,49 +39,40 @@ namespace BH.Adapter.Lusas
 
             IFAttribute lusasMaterial = null;
             string lusasName = "M" + material.CustomData[AdapterIdName] + "/" + material.Name;
-
+            
             if (material is IIsotropic)
             {
                 IIsotropic isotropic = material as IIsotropic;
-
                 if (d_LusasData.existsAttribute("Material", lusasName))
                 {
-
                     lusasMaterial = d_LusasData.getAttribute("Material", lusasName);
                 }
-
                 else
                 {
                     lusasMaterial = d_LusasData.createIsotropicMaterial(material.Name,
                     isotropic.YoungsModulus, isotropic.PoissonsRatio, isotropic.Density, isotropic.ThermalExpansionCoeff);
-
                     lusasMaterial.setName(lusasName);
                 }
             }
             else if (material is IOrthotropic)
             {
                 IOrthotropic iorthotropic = material as IOrthotropic;
-
                 if (d_LusasData.existsAttribute("Material", lusasName))
                 {
-
                     lusasMaterial = d_LusasData.getAttribute("Material", lusasName);
                 }
-
                 else
                 {
-               
-                    lusasMaterial = d_LusasData.createOrthotropicAxisymmetricMaterial(material.Name, 
+                    lusasMaterial = d_LusasData.createOrthotropicAxisymmetricMaterial(material.Name,
                         iorthotropic.YoungsModulus.X, iorthotropic.YoungsModulus.Y, iorthotropic.YoungsModulus.Z,
                         iorthotropic.ShearModulus.X, iorthotropic.PoissonsRatio.X, iorthotropic.PoissonsRatio.Y, iorthotropic.PoissonsRatio.Z,
                         0.0, iorthotropic.Density, 0.0);
-
-                    lusasMaterial.setValue( "ax", iorthotropic.ThermalExpansionCoeff.X);
+                    lusasMaterial.setValue("ax", iorthotropic.ThermalExpansionCoeff.X);
                     lusasMaterial.setValue("ay", iorthotropic.ThermalExpansionCoeff.Y);
                     lusasMaterial.setValue("az", iorthotropic.ThermalExpansionCoeff.Z);
 
-                    Vector ThermalExpansionCoeffxy = new Vector ()
-                        { X = iorthotropic.ThermalExpansionCoeff.X, Y = iorthotropic.ThermalExpansionCoeff.Y, Z= 0 };
+                    Vector ThermalExpansionCoeffxy = new Vector()
+                    { X = iorthotropic.ThermalExpansionCoeff.X, Y = iorthotropic.ThermalExpansionCoeff.Y, Z = 0 };
                     double XY = ThermalExpansionCoeffxy.Length();
                     lusasMaterial.setValue("axy", XY);
 

--- a/Lusas_Adapter/CRUD/Create/Properties/Material.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Material.cs
@@ -72,15 +72,18 @@ namespace BH.Adapter.Lusas
                 {
                
                     lusasMaterial = d_LusasData.createOrthotropicAxisymmetricMaterial(material.Name, 
-                        iorthotropic.YoungsModulus.X, iorthotropic.YoungsModulus.Y, iorthotropic.YoungsModulus.Z,
-                        iorthotropic.ShearModulus.X, iorthotropic.PoissonsRatio.X, iorthotropic.PoissonsRatio.Y, iorthotropic.PoissonsRatio.Z,
-                        0.0, iorthotropic.Density, 0.0);
+                    iorthotropic.YoungsModulus.X, iorthotropic.YoungsModulus.Y, iorthotropic.YoungsModulus.Z,
+                    iorthotropic.ShearModulus.X, iorthotropic.PoissonsRatio.X, iorthotropic.PoissonsRatio.Y, iorthotropic.PoissonsRatio.Z,
+                    0.0, iorthotropic.Density, 0.0);
+
                     lusasMaterial.setValue( "ax", iorthotropic.ThermalExpansionCoeff.X);
                     lusasMaterial.setValue("ay", iorthotropic.ThermalExpansionCoeff.Y);
                     lusasMaterial.setValue("az", iorthotropic.ThermalExpansionCoeff.Z);
+
                     Vector ThermalExpansionCoeffxy = new Vector () { X = iorthotropic.ThermalExpansionCoeff.X, Y = iorthotropic.ThermalExpansionCoeff.Y, Z= 0 };
                     double XY = ThermalExpansionCoeffxy.Length();
                     lusasMaterial.setValue("axy", XY);
+
                     lusasMaterial.setName(lusasName);
                 }
             }

--- a/Lusas_Adapter/CRUD/Read/Properties/Materials.cs
+++ b/Lusas_Adapter/CRUD/Read/Properties/Materials.cs
@@ -43,5 +43,6 @@ namespace BH.Adapter.Lusas
 
             return bhomMaterials;
         }
+
     }
 }

--- a/Lusas_Adapter/Type/NextFreeId.cs
+++ b/Lusas_Adapter/Type/NextFreeId.cs
@@ -141,7 +141,7 @@ namespace BH.Adapter.Lusas
                     else
                     {
                         IFLoadset largestLoadset = d_LusasData.getLoadset(largestLoadcaseID);
-                        if(largestLoadset is IFLoadcase)
+                        if (largestLoadset is IFLoadcase)
                         {
                             IFLoadcase largestLoadcase = (IFLoadcase)largestLoadset;
                             index = System.Convert.ToInt32(
@@ -155,7 +155,9 @@ namespace BH.Adapter.Lusas
                         }
                     }
                 }
-                if (type == typeof(IMaterialFragment))
+                if (type == typeof(Timber) || type == typeof(Steel) || type == typeof(Concrete) ||
+                    type == typeof(GenericIsotropicMaterial) || type == typeof(GenericOrthotropicMaterial) ||
+                    type == typeof(Aluminium))
                 {
                     int largestMaterialID = d_LusasData.getLargestAttributeID("Material");
                     if (largestMaterialID == 0)
@@ -164,7 +166,6 @@ namespace BH.Adapter.Lusas
                     }
                     else
                     {
-
                         IFAttribute largestAttribute = d_LusasData.getAttribute("Material", largestMaterialID);
                         index = System.Convert.ToInt32(
                             Engine.Lusas.Query.GetAdapterID(largestAttribute, 'M')) + 1;
@@ -219,7 +220,7 @@ namespace BH.Adapter.Lusas
                     else
                     {
                         IFAttribute largestAttribute = d_LusasData.getAttribute("Loading", largestLoadID);
-                        if(largestAttribute is IFPrescribedDisplacementLoad)
+                        if (largestAttribute is IFPrescribedDisplacementLoad)
                         {
                             index = System.Convert.ToInt32(
                                 Engine.Lusas.Query.GetAdapterID(largestAttribute, 'd')) + 1;
@@ -231,7 +232,6 @@ namespace BH.Adapter.Lusas
                         }
                     }
                 }
-
                 if (type == typeof(MeshSettings1D) ||
                     type == typeof(MeshSettings2D))
                 {
@@ -261,6 +261,7 @@ namespace BH.Adapter.Lusas
 
 
         /***************************************************/
+
     }
 }
 

--- a/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
@@ -51,14 +51,14 @@ namespace BH.Engine.Lusas
             {
                 bhomMaterial = Engine.Structure.Create.Timber(
                 attributeName,
-                new Vector() { X = lusasAttribute.getValue("Ex"), Y = lusasAttribute.getValue("Ey"), Z = lusasAttribute.getValue("Ez") },
-                new Vector() { X = lusasAttribute.getValue("nuxy"), Y = lusasAttribute.getValue("nuyz"), Z = lusasAttribute.getValue("nuzx") },
-                new Vector() { X = lusasAttribute.getValue("Gxy"), Y = 0.0, Z = 0.0 },
-                new Vector() { X = lusasAttribute.getValue("ax"), Y = lusasAttribute.getValue("ay"), Z = lusasAttribute.getValue("az") },
-                lusasAttribute.getValue("rho"), 0, 0);
+                    new Vector() { X = lusasAttribute.getValue("Ex"), Y = lusasAttribute.getValue("Ey"), Z = lusasAttribute.getValue("Ez") },
+                    new Vector() { X = lusasAttribute.getValue("nuxy"), Y = lusasAttribute.getValue("nuyz"), Z = lusasAttribute.getValue("nuzx") },
+                    new Vector() { X = lusasAttribute.getValue("Gxy"), Y = 0.0, Z = 0.0 },
+                    new Vector() { X = lusasAttribute.getValue("ax"), Y = lusasAttribute.getValue("ay"), Z = lusasAttribute.getValue("az") },
+                    lusasAttribute.getValue("rho"), 0, 0);
 
                 Engine.Reflection.Compute.RecordWarning
-                ("Orthotropic materials in Lusas will default to a TimberMaterial.");
+                    ("Orthotropic materials in Lusas will default to a TimberMaterial.");
             }
 
             int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'M');

--- a/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
@@ -21,6 +21,9 @@
  */
 
 using BH.oM.Structure.MaterialFragments;
+using BH.Engine.Structure;
+using BH.oM.Geometry;
+using BH.Engine.Geometry;
 using Lusas.LPI;
 
 namespace BH.Engine.Lusas
@@ -31,23 +34,46 @@ namespace BH.Engine.Lusas
         {
             string attributeName = Lusas.Query.GetName(lusasAttribute);
 
-            IMaterialFragment bhomMaterial = Engine.Structure.Create.Steel(
-                attributeName, 
-                lusasAttribute.getValue("E"), 
+            IMaterialFragment bhomMaterial = null;
+            if (lusasAttribute is IFMaterialIsotropic)
+            {
+
+                IMaterialFragment bhomMaterials = Engine.Structure.Create.Steel(
+                attributeName,
+                lusasAttribute.getValue("E"),
                 lusasAttribute.getValue("nu"),
-                lusasAttribute.getValue("alpha"), 
-                lusasAttribute.getValue("rho"), 
+                lusasAttribute.getValue("alpha"),
+                lusasAttribute.getValue("rho"),
                 0, 0, 0);
 
-            Engine.Reflection.Compute.RecordWarning("Isotropic materials in Lusas will default to a SteelMaterial. Properties for " + attributeName + " are stored in a SteelMaterial");
+                Engine.Reflection.Compute.RecordWarning("Isotropic materials in Lusas will default to a SteelMaterial. Properties for " + attributeName + " are stored in a SteelMaterial");
 
-            int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'M');
-            bhomMaterial.CustomData["Lusas_id"] = adapterID;
+                int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'M');
+                bhomMaterials.CustomData["Lusas_id"] = adapterID;
+                bhomMaterial = bhomMaterials;
+            }
+            else if (lusasAttribute is IFMaterialOrthotropic)
+               
+                    {
 
-            return bhomMaterial;
-        }
+                Vector YE = new Vector () { X= lusasAttribute.getValue("Ex"), Y= lusasAttribute.getValue("Ey"), Z= lusasAttribute.getValue("Ez") };
+                Vector V = new Vector() { X = lusasAttribute.getValue("nuxy"), Y = lusasAttribute.getValue("nuyz"), Z = lusasAttribute.getValue("nuzx") };
+                Vector Z = new Vector() { X = lusasAttribute.getValue("Gxy"),Y= 0.0, Z= 0.0 };
+                Vector tc = new Vector() { X = lusasAttribute.getValue("ax"), Y = lusasAttribute.getValue("ay"), Z = lusasAttribute.getValue("az") };
+                IMaterialFragment bhomMaterials = Engine.Structure.Create.Timber(
+                attributeName, YE, V, Z, tc, lusasAttribute.getValue("rho"), 0, 0);
 
 
+                Engine.Reflection.Compute.RecordWarning("orthotropic materials in Lusas will default to a timberMaterial. Properties for " + attributeName + " are stored in a TimberMaterial");
+
+                int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'M');
+                bhomMaterials.CustomData["Lusas_id"] = adapterID;
+                bhomMaterial = bhomMaterials;
+
+            }
+                return bhomMaterial;
+            }
+                       }
+        
     }
-}
 

--- a/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
@@ -21,9 +21,7 @@
  */
 
 using BH.oM.Structure.MaterialFragments;
-using BH.Engine.Structure;
 using BH.oM.Geometry;
-using BH.Engine.Geometry;
 using Lusas.LPI;
 
 namespace BH.Engine.Lusas
@@ -37,43 +35,38 @@ namespace BH.Engine.Lusas
             IMaterialFragment bhomMaterial = null;
             if (lusasAttribute is IFMaterialIsotropic)
             {
+                bhomMaterial = new GenericIsotropicMaterial()
+                {
+                    Name = attributeName,
+                    YoungsModulus = lusasAttribute.getValue("E"),
+                    PoissonsRatio = lusasAttribute.getValue("nu"),
+                    ThermalExpansionCoeff = lusasAttribute.getValue("alpha"),
+                    Density = lusasAttribute.getValue("rho")
+                };
 
-                IMaterialFragment bhomMaterials = Engine.Structure.Create.Steel(
-                attributeName,
-                lusasAttribute.getValue("E"),
-                lusasAttribute.getValue("nu"),
-                lusasAttribute.getValue("alpha"),
-                lusasAttribute.getValue("rho"),
-                0, 0, 0);
-
-                Engine.Reflection.Compute.RecordWarning("Isotropic materials in Lusas will default to a SteelMaterial. Properties for " + attributeName + " are stored in a SteelMaterial");
-
-                int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'M');
-                bhomMaterials.CustomData["Lusas_id"] = adapterID;
-                bhomMaterial = bhomMaterials;
+                Engine.Reflection.Compute.RecordWarning
+                ("Isotropic materials in Lusas will default to a GenericIsotropicMaterial");
             }
             else if (lusasAttribute is IFMaterialOrthotropic)
-               
-                    {
+            {
+                bhomMaterial = Engine.Structure.Create.Timber(
+                attributeName,
+                new Vector() { X = lusasAttribute.getValue("Ex"), Y = lusasAttribute.getValue("Ey"), Z = lusasAttribute.getValue("Ez") },
+                new Vector() { X = lusasAttribute.getValue("nuxy"), Y = lusasAttribute.getValue("nuyz"), Z = lusasAttribute.getValue("nuzx") },
+                new Vector() { X = lusasAttribute.getValue("Gxy"), Y = 0.0, Z = 0.0 },
+                new Vector() { X = lusasAttribute.getValue("ax"), Y = lusasAttribute.getValue("ay"), Z = lusasAttribute.getValue("az") },
+                lusasAttribute.getValue("rho"), 0, 0);
 
-                Vector YE = new Vector () { X= lusasAttribute.getValue("Ex"), Y= lusasAttribute.getValue("Ey"), Z= lusasAttribute.getValue("Ez") };
-                Vector V = new Vector() { X = lusasAttribute.getValue("nuxy"), Y = lusasAttribute.getValue("nuyz"), Z = lusasAttribute.getValue("nuzx") };
-                Vector Z = new Vector() { X = lusasAttribute.getValue("Gxy"),Y= 0.0, Z= 0.0 };
-                Vector tc = new Vector() { X = lusasAttribute.getValue("ax"), Y = lusasAttribute.getValue("ay"), Z = lusasAttribute.getValue("az") };
-                IMaterialFragment bhomMaterials = Engine.Structure.Create.Timber(
-                attributeName, YE, V, Z, tc, lusasAttribute.getValue("rho"), 0, 0);
-
-
-                Engine.Reflection.Compute.RecordWarning("orthotropic materials in Lusas will default to a timberMaterial. Properties for " + attributeName + " are stored in a TimberMaterial");
-
-                int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'M');
-                bhomMaterials.CustomData["Lusas_id"] = adapterID;
-                bhomMaterial = bhomMaterials;
-
+                Engine.Reflection.Compute.RecordWarning
+                ("Orthotropic materials in Lusas will default to a TimberMaterial.");
             }
-                return bhomMaterial;
-            }
-                       }
-        
+
+            int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'M');
+            bhomMaterial.CustomData["Lusas_id"] = adapterID;
+
+            return bhomMaterial;
+        }
+
     }
+}
 

--- a/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
@@ -58,7 +58,7 @@ namespace BH.Engine.Lusas
                     lusasAttribute.getValue("rho"), 0, 0);
 
                 Engine.Reflection.Compute.RecordWarning
-                    ("Orthotropic materials in Lusas will default to a TimberMaterial.");
+                    ("Orthotropic materials in Lusas will default to a TimberMaterial");
             }
 
             int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'M');


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/654
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #209 

<!-- Add short description of what has been fixed -->
Added push/pull of `Timber`, `Aluminium `and `GenericMaterial`.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EsQlafvDiRFNpTXmRtnF9KQBptvTQ_5ceJRPGNEpnq4xWA?e=W6MexZ

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added functionality for pushing/pulling of `Timber`, `Aluminium`, `GenericOrthotropic` and `GenericIsoptropic`

### Additional comments
<!-- As required -->