### PR TITLE
Add support for GenericSection, TimberSection and AluminiumSection

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -339,7 +339,7 @@ namespace BH.Adapter.Lusas
 
             foreach (IFPoint point in lusasPoints)
             {
-                bhomPoints.Add(Engine.Lusas.Convert.ToBHoMPoint(point));
+                bhomPoints.Add(Engine.Lusas.Convert.ToPoint(point));
             }
 
             CreateTags(distinctEdges);

--- a/Lusas_Adapter/CRUD/Create/Elements/Line.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Line.cs
@@ -23,6 +23,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Structure.Elements;
+using BH.oM.Structure.MaterialFragments;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using Lusas.LPI;
@@ -66,6 +67,13 @@ namespace BH.Adapter.Lusas
                         bar.SectionProperty.Material.Name;
 
                     IFAttribute lusasMaterial = d_LusasData.getAttribute("Material", materialName);
+
+                    if(bar.SectionProperty.Material is IOrthotropic)
+                    {
+                        Engine.Reflection.Compute.RecordWarning($"Orthotropic Material {bar.SectionProperty.Material.Name} cannot be assigned to Bar {bar.CustomData[AdapterIdName]}, " +
+                            $"orthotropic can only be applied to 2D and 3D elements in Lusas.");
+                    }
+
                     lusasMaterial.assignTo(lusasLine);
                 }
             }

--- a/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
@@ -62,10 +62,11 @@ namespace BH.Adapter.Lusas
 
         private IFAttribute CreateSection(ConcreteSection sectionProperty, string lusasName)
         {
-            Engine.Reflection.Compute.RecordError("ConcreteSection not supported in Lusas_Toolkit");
-            return null;
+            IFAttribute lusasGeometricLine = CreateProfile(
+             sectionProperty.SectionProfile as dynamic, lusasName
+             );
+            return lusasGeometricLine;
         }
-
         private IFAttribute CreateSection(ExplicitSection sectionProperty, string lusasName)
         {
             Engine.Reflection.Compute.RecordError("ExplicitSection not supported in Lusas_Toolkit");

--- a/Lusas_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Bars.cs
@@ -66,7 +66,7 @@ namespace BH.Adapter.Lusas
                 for (int i = 0; i < lusasLines.Count(); i++)
                 {
                     IFLine lusasLine = (IFLine)lusasLines[i];
-                    Bar bhomBar = Engine.Lusas.Convert.ToBHoMBar
+                    Bar bhomBar = Engine.Lusas.Convert.ToBar
                         (
                         lusasLine,
                         bhomNodes,

--- a/Lusas_Adapter/CRUD/Read/Elements/Edges.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Edges.cs
@@ -45,7 +45,7 @@ namespace BH.Adapter.Lusas
                 for (int i = 0; i < lusasLines.Count(); i++)
                 {
                     IFLine lusasLine = (IFLine)lusasLines[i];
-                    Edge bhomEdge = Engine.Lusas.Convert.ToBHoMEdge(lusasLine, bhomNodes, groupNames);
+                    Edge bhomEdge = Engine.Lusas.Convert.ToEdge(lusasLine, bhomNodes, groupNames);
                     bhomEdges.Add(bhomEdge);
                 }
             }

--- a/Lusas_Adapter/CRUD/Read/Elements/Nodes.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Nodes.cs
@@ -46,7 +46,7 @@ namespace BH.Adapter.Lusas
                 for (int i = 0; i < lusasPoints.Count(); i++)
                 {
                     IFPoint lusasPoint = (IFPoint)lusasPoints[i];
-                    Node bhomNode = Engine.Lusas.Convert.ToBHoMNode(lusasPoint, groupNames, constraints6DOF);
+                    Node bhomNode = Engine.Lusas.Convert.ToNode(lusasPoint, groupNames, constraints6DOF);
                     bhomNodes.Add(bhomNode);
                 }
             }

--- a/Lusas_Adapter/CRUD/Read/Elements/PlanarPanels.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/PlanarPanels.cs
@@ -59,7 +59,7 @@ namespace BH.Adapter.Lusas
                 for (int i = 0; i < lusasSurfaces.Count(); i++)
                 {
                     IFSurface lusasSurface = (IFSurface)lusasSurfaces[i];
-                    Panel bhomPanel = Engine.Lusas.Convert.ToBHoMPanel(lusasSurface,
+                    Panel bhomPanel = Engine.Lusas.Convert.ToPanel(lusasSurface,
                         bhomEdges,
                         groupNames,
                         geometrics,

--- a/Lusas_Adapter/CRUD/Read/Elements/Points.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Points.cs
@@ -41,7 +41,7 @@ namespace BH.Adapter.Lusas
                 for (int i = 0; i < lusasPoints.Count(); i++)
                 {
                     IFPoint lusasPoint = (IFPoint)lusasPoints[i];
-                    Point bhomPoint = Engine.Lusas.Convert.ToBHoMPoint(lusasPoint, groupNames);
+                    Point bhomPoint = Engine.Lusas.Convert.ToPoint(lusasPoint, groupNames);
                     bhomPoints.Add(bhomPoint);
                 }
             }

--- a/Lusas_Adapter/CRUD/Read/Loads/BarPointLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/BarPointLoads.cs
@@ -53,7 +53,7 @@ namespace BH.Adapter.Lusas
                     foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
                     {
                         BarPointLoad bhomBarPointLoad =
-                            Engine.Lusas.Convert.ToBHoMBarPointLoad(
+                            Engine.Lusas.Convert.ToBarPointLoad(
                                 lusasInternalBeamPointLoad, groupedAssignment, barDictionary);
 
                         List<string> analysisName = new List<string> { lusasInternalBeamPointLoad.getAttributeType() };

--- a/Lusas_Adapter/CRUD/Read/Loads/BarVaryingDistributedLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/BarVaryingDistributedLoads.cs
@@ -53,7 +53,7 @@ namespace BH.Adapter.Lusas
                     foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
                     {
                         BarVaryingDistributedLoad bhomBarDistributedLoad =
-                            Engine.Lusas.Convert.ToBHoMBarDistributedLoad(
+                            Engine.Lusas.Convert.ToBarDistributedLoad(
                                 lusasInternalBeamDistributedLoad, groupedAssignment, barDictionary);
 
                         List<string> analysisName = new List<string> {

--- a/Lusas_Adapter/CRUD/Read/Loads/LoadCombinations.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/LoadCombinations.cs
@@ -44,7 +44,7 @@ namespace BH.Adapter.Lusas
                 {
                     IFBasicCombination lusasCombination = (IFBasicCombination)lusasCombinations[i];
                     LoadCombination bhomLoadCombination =
-                        Engine.Lusas.Convert.ToBHoMLoadCombination(lusasCombination, loadcaseDictionary);
+                        Engine.Lusas.Convert.ToLoadCombination(lusasCombination, loadcaseDictionary);
                     bhomLoadCombintations.Add(bhomLoadCombination);
                 }
             }

--- a/Lusas_Adapter/CRUD/Read/Loads/Loadcases.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/Loadcases.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.Lusas
             for (int i = 0; i < allLoadcases.Count(); i++)
             {
                 IFLoadcase lusasLoadcase = (IFLoadcase)allLoadcases[i];
-                Loadcase bhomLoadcase = Engine.Lusas.Convert.ToBHoMLoadcase(lusasLoadcase);
+                Loadcase bhomLoadcase = Engine.Lusas.Convert.ToLoadcase(lusasLoadcase);
                 List<string> analysisName = new List<string> { lusasLoadcase.getAnalysis().getName() };
                 bhomLoadcase.Tags = new HashSet<string>(analysisName);
                 bhomLoadcases.Add(bhomLoadcase);

--- a/Lusas_Adapter/CRUD/Read/Properties/4DOFConstraints.cs
+++ b/Lusas_Adapter/CRUD/Read/Properties/4DOFConstraints.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.Lusas
             for (int i = 0; i < lusasSupports.Count(); i++)
             {
                 IFSupportStructural lusasSupport = (IFSupportStructural)lusasSupports[i];
-                Constraint4DOF bhomConstraint4DOF = Engine.Lusas.Convert.ToBHoMConstraint4DOF(lusasSupport);
+                Constraint4DOF bhomConstraint4DOF = Engine.Lusas.Convert.ToConstraint4DOF(lusasSupport);
                 bhomConstraints4DOFs.Add(bhomConstraint4DOF);
             }
 

--- a/Lusas_Adapter/CRUD/Read/Properties/6DOFConstraints.cs
+++ b/Lusas_Adapter/CRUD/Read/Properties/6DOFConstraints.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.Lusas
             for (int i = 0; i < lusasSupports.Count(); i++)
             {
                 IFSupportStructural lusasSupport = (IFSupportStructural)lusasSupports[i];
-                Constraint6DOF bhomConstraint6DOF = Engine.Lusas.Convert.ToBHoMConstraint6DOF(lusasSupport);
+                Constraint6DOF bhomConstraint6DOF = Engine.Lusas.Convert.ToConstraint6DOF(lusasSupport);
                 bhomConstraints6DOF.Add(bhomConstraint6DOF);
             }
 

--- a/Lusas_Adapter/CRUD/Read/Properties/Materials.cs
+++ b/Lusas_Adapter/CRUD/Read/Properties/Materials.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.Lusas
             for (int i = 0; i < lusasMaterials.Count(); i++)
             {
                 IFAttribute lusasMaterial = (IFAttribute)lusasMaterials[i];
-                IMaterialFragment bhomMaterial = Engine.Lusas.Convert.ToBHoMMaterial(lusasMaterial);
+                IMaterialFragment bhomMaterial = Engine.Lusas.Convert.ToMaterial(lusasMaterial);
                 bhomMaterials.Add(bhomMaterial);
             }
 

--- a/Lusas_Adapter/CRUD/Read/Properties/MeshSettings1D.cs
+++ b/Lusas_Adapter/CRUD/Read/Properties/MeshSettings1D.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.Lusas
             for (int i = 0; i < lusasMesh1Ds.Count(); i++)
             {
                 IFMeshLine lusasMesh1D = (IFMeshLine)lusasMesh1Ds[i];
-                MeshSettings1D bhomMeshSettings1D = Engine.Lusas.Convert.ToBHoMMeshSettings1D(lusasMesh1D);
+                MeshSettings1D bhomMeshSettings1D = Engine.Lusas.Convert.ToMeshSettings1D(lusasMesh1D);
                 List<string> analysisName = new List<string> { lusasMesh1D.getAttributeType() };
                 bhomMeshSettings1D.Tags = new HashSet<string>(analysisName);
                 bhomMeshSettings1Ds.Add(bhomMeshSettings1D);

--- a/Lusas_Adapter/CRUD/Read/Properties/MeshSettings2D.cs
+++ b/Lusas_Adapter/CRUD/Read/Properties/MeshSettings2D.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.Lusas
             for (int i = 0; i < lusasMesh2Ds.Count(); i++)
             {
                 IFMeshSurface lusasMesh2D = (IFMeshSurface)lusasMesh2Ds[i];
-                MeshSettings2D bhomMeshSettings2D = Engine.Lusas.Convert.ToBHoMMeshSettings2D(lusasMesh2D);
+                MeshSettings2D bhomMeshSettings2D = Engine.Lusas.Convert.ToMeshSettings2D(lusasMesh2D);
                 List<string> analysisName = new List<string> { lusasMesh2D.getAttributeType() };
                 bhomMeshSettings2D.Tags = new HashSet<string>(analysisName);
                 bhomMeshSettings2Ds.Add(bhomMeshSettings2D);

--- a/Lusas_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/Lusas_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.Lusas
             for (int i = 0; i < lusasSections.Count(); i++)
             {
                 IFAttribute lusasSection = (IFAttribute)lusasSections[i];
-                ISectionProperty bhomSection = Engine.Lusas.Convert.ToBHoMSection(lusasSection);
+                ISectionProperty bhomSection = Engine.Lusas.Convert.ToSection(lusasSection);
                 bhomSections.Add(bhomSection);
             }
             return bhomSections;

--- a/Lusas_Adapter/CRUD/Read/Properties/SurfaceProperties.cs
+++ b/Lusas_Adapter/CRUD/Read/Properties/SurfaceProperties.cs
@@ -37,7 +37,7 @@ namespace BH.Adapter.Lusas
             for (int i = 0; i < lusasGeometrics.Count(); i++)
             {
                 IFAttribute lusasGeometric = (IFAttribute)lusasGeometrics[i];
-                ISurfaceProperty bhomProperty2D = Engine.Lusas.Convert.ToBHoMSurfaceProperty(lusasGeometric);
+                ISurfaceProperty bhomProperty2D = Engine.Lusas.Convert.ToSurfaceProperty(lusasGeometric);
                 bhomProperties2D.Add(bhomProperty2D);
             }
 

--- a/Lusas_Adapter/Type/NextFreeId.cs
+++ b/Lusas_Adapter/Type/NextFreeId.cs
@@ -187,8 +187,8 @@ namespace BH.Adapter.Lusas
                             Engine.Lusas.Query.GetAdapterID(largestAttribute, 'p')) + 1;
                     }
                 }
-                if (type == typeof(ConstantThickness) ||
-                    type == typeof(SteelSection))
+                if (type == typeof(ConstantThickness) || type == typeof(SteelSection) || type == typeof(ConcreteSection) 
+                    || type == typeof(TimberSection) || type == typeof(AluminiumSection) || type == typeof(GenericSection))
                 {
                     int largestThicknessID = d_LusasData.getLargestAttributeID("Geometric");
                     if (largestThicknessID == 0)

--- a/Lusas_Adapter/Type/NextFreeId.cs
+++ b/Lusas_Adapter/Type/NextFreeId.cs
@@ -130,8 +130,7 @@ namespace BH.Adapter.Lusas
                             Engine.Lusas.Modify.RemovePrefix(largestPoint.getName(), "P")) + 1;
                     }
                 }
-                if (type == typeof(Loadcase) ||
-                    type == typeof(LoadCombination))
+                if (typeof(ICase).IsAssignableFrom(type))
                 {
                     int largestLoadcaseID = d_LusasData.getNextAvailableLoadcaseID() - 1;
                     if (largestLoadcaseID == 0)
@@ -155,9 +154,7 @@ namespace BH.Adapter.Lusas
                         }
                     }
                 }
-                if (type == typeof(Timber) || type == typeof(Steel) || type == typeof(Concrete) ||
-                    type == typeof(GenericIsotropicMaterial) || type == typeof(GenericOrthotropicMaterial) ||
-                    type == typeof(Aluminium))
+                if (typeof(IMaterialFragment).IsAssignableFrom(type))
                 {
                     int largestMaterialID = d_LusasData.getLargestAttributeID("Material");
                     if (largestMaterialID == 0)
@@ -187,8 +184,7 @@ namespace BH.Adapter.Lusas
                             Engine.Lusas.Query.GetAdapterID(largestAttribute, 'p')) + 1;
                     }
                 }
-                if (type == typeof(ConstantThickness) || type == typeof(SteelSection) || type == typeof(ConcreteSection) 
-                    || type == typeof(TimberSection) || type == typeof(AluminiumSection) || type == typeof(GenericSection))
+                if (typeof(ISectionProperty).IsAssignableFrom(type) || typeof(ISurfaceProperty).IsAssignableFrom(type))
                 {
                     int largestThicknessID = d_LusasData.getLargestAttributeID("Geometric");
                     if (largestThicknessID == 0)
@@ -202,15 +198,7 @@ namespace BH.Adapter.Lusas
                             Engine.Lusas.Query.GetAdapterID(largestAttribute, 'G')) + 1;
                     }
                 }
-                if (type == typeof(PointLoad) ||
-                    type == typeof(GravityLoad) ||
-                    type == typeof(BarUniformlyDistributedLoad) ||
-                    type == typeof(AreaUniformlyDistributedLoad) ||
-                    type == typeof(BarTemperatureLoad) ||
-                    type == typeof(AreaTemperatureLoad) ||
-                    type == typeof(BarPointLoad) ||
-                    type == typeof(BarVaryingDistributedLoad) ||
-                    type == typeof(PointDisplacement))
+                if (typeof(ILoad).IsAssignableFrom(type))
                 {
                     int largestLoadID = d_LusasData.getLargestAttributeID("Loading");
                     if (largestLoadID == 0)

--- a/Lusas_Engine/Convert/ToBHoM/Elements/Bar.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/Bar.cs
@@ -34,7 +34,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static Bar ToBHoMBar(this IFLine lusasLine, 
+        public static Bar ToBar(this IFLine lusasLine, 
             Dictionary<string, Node> bhomNodes, 
             Dictionary<string, Constraint4DOF> bhomSupports,
             HashSet<string> lusasGroups,

--- a/Lusas_Engine/Convert/ToBHoM/Elements/Edge.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/Edge.cs
@@ -29,7 +29,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static Edge ToBHoMEdge(this IFLine lusasLine,
+        public static Edge ToEdge(this IFLine lusasLine,
             Dictionary<string, Node> bhomNodes, HashSet<string> groupNames)
         {
             Node startNode = Engine.Lusas.Query.GetNode(lusasLine, 0, bhomNodes);

--- a/Lusas_Engine/Convert/ToBHoM/Elements/Node.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/Node.cs
@@ -31,7 +31,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static Node ToBHoMNode(this IFPoint lusasPoint,
+        public static Node ToNode(this IFPoint lusasPoint,
             HashSet<string> groupNames, Dictionary<string, Constraint6DOF> bhom6DOFConstraints)
         {
             HashSet<string> tags = new HashSet<string>(Query.IsMemberOf(lusasPoint, groupNames));

--- a/Lusas_Engine/Convert/ToBHoM/Elements/PanelPlanar.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/PanelPlanar.cs
@@ -33,7 +33,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static Panel ToBHoMPanel(this IFSurface lusasSurface,
+        public static Panel ToPanel(this IFSurface lusasSurface,
             Dictionary<string, Edge> bhomEdges,
             HashSet<string> groupNames,
             Dictionary<string, ISurfaceProperty> bhom2DProperties,

--- a/Lusas_Engine/Convert/ToBHoM/Elements/Point.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/Point.cs
@@ -28,7 +28,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static Point ToBHoMPoint(this IFPoint lusasPoint, HashSet<string> groupNames)
+        public static Point ToPoint(this IFPoint lusasPoint, HashSet<string> groupNames)
         {
             HashSet<string> tags = new HashSet<string>(Query.IsMemberOf(lusasPoint, groupNames));
 

--- a/Lusas_Engine/Convert/ToBHoM/Elements/Point.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/Point.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Lusas
             return bhomPoint;
         }
 
-        public static Point ToBHoMPoint(this IFPoint lusasPoint)
+        public static Point ToPoint(this IFPoint lusasPoint)
         {
             Point bhomPoint = new Point { X = lusasPoint.getX(), Y = lusasPoint.getY(), Z = lusasPoint.getZ() };
 

--- a/Lusas_Engine/Convert/ToBHoM/Loads/AreaTemperatureLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/AreaTemperatureLoad.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Lusas
             Dictionary<string, Panel> PanelDictionary)
         {
             IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
-            Loadcase bhomLoadcase = ToBHoMLoadcase(assignedLoadcase);
+            Loadcase bhomLoadcase = ToLoadcase(assignedLoadcase);
             double temperatureChange = lusasTemperatureLoad.getValue("T")
                 - lusasTemperatureLoad.getValue("T0");
 

--- a/Lusas_Engine/Convert/ToBHoM/Loads/AreaUniformlyDistributedLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/AreaUniformlyDistributedLoad.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Lusas
             Dictionary<string, Panel> PanelDictionary)
         {
             IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
-            Loadcase bhomLoadcase = ToBHoMLoadcase(assignedLoadcase);
+            Loadcase bhomLoadcase = ToLoadcase(assignedLoadcase);
 
             IEnumerable<IAreaElement> bhomPanels = Lusas.Query.GetSurfaceAssignments(
                 lusasAssignments, PanelDictionary);

--- a/Lusas_Engine/Convert/ToBHoM/Loads/BarDistributedLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/BarDistributedLoad.cs
@@ -31,11 +31,11 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static BarVaryingDistributedLoad ToBHoMBarDistributedLoad(IFLoading lusasBarDistributedLoad,
+        public static BarVaryingDistributedLoad ToBarDistributedLoad(IFLoading lusasBarDistributedLoad,
             IEnumerable<IFAssignment> lusasAssignments, Dictionary<string, Bar> bhomBarDictionary)
         {
             IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
-            Loadcase bhomLoadcase = ToBHoMLoadcase(assignedLoadcase);
+            Loadcase bhomLoadcase = ToLoadcase(assignedLoadcase);
 
             IEnumerable<Bar> bhomBars = Lusas.Query.GetBarAssignments(lusasAssignments, bhomBarDictionary);
 

--- a/Lusas_Engine/Convert/ToBHoM/Loads/BarPointLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/BarPointLoad.cs
@@ -31,11 +31,11 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static BarPointLoad ToBHoMBarPointLoad(IFLoading lusasBarPointLoad,
+        public static BarPointLoad ToBarPointLoad(IFLoading lusasBarPointLoad,
             IEnumerable<IFAssignment> lusasAssignments, Dictionary<string, Bar> bhomBarDictionary)
         {
             IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
-            Loadcase bhomLoadcase = ToBHoMLoadcase(assignedLoadcase);
+            Loadcase bhomLoadcase = ToLoadcase(assignedLoadcase);
 
             IEnumerable<Bar> bhomBars = Lusas.Query.GetBarAssignments(lusasAssignments, bhomBarDictionary);
 

--- a/Lusas_Engine/Convert/ToBHoM/Loads/BarTemperatureLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/BarTemperatureLoad.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Lusas
             Dictionary<string, Bar> bars)
         {
             IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
-            Loadcase bhomLoadcase = ToBHoMLoadcase(assignedLoadcase);
+            Loadcase bhomLoadcase = ToLoadcase(assignedLoadcase);
             double temperatureChange = lusasTemperatureLoad.getValue("T")
                 - lusasTemperatureLoad.getValue("T0");
 

--- a/Lusas_Engine/Convert/ToBHoM/Loads/BarUniformlyDistributedLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/BarUniformlyDistributedLoad.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Lusas
             IEnumerable<IFAssignment> lusasAssignments, Dictionary<string, Bar> bhomBarDictionary)
         {
             IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
-            Loadcase bhomLoadcase = ToBHoMLoadcase(assignedLoadcase);
+            Loadcase bhomLoadcase = ToLoadcase(assignedLoadcase);
 
             IEnumerable<Bar> bhomBars = Lusas.Query.GetBarAssignments(lusasAssignments, bhomBarDictionary);
 

--- a/Lusas_Engine/Convert/ToBHoM/Loads/GravityLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/GravityLoad.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Lusas
             Dictionary<string, Panel> bhomPanels)
         {
             IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
-            Loadcase bhomLoadcase = ToBHoMLoadcase(assignedLoadcase);
+            Loadcase bhomLoadcase = ToLoadcase(assignedLoadcase);
             Vector gravityVector = new Vector
             {
                 X = lusasGravityLoad.getValue("accX"),

--- a/Lusas_Engine/Convert/ToBHoM/Loads/LoadCombination.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/LoadCombination.cs
@@ -30,7 +30,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static LoadCombination ToBHoMLoadCombination(
+        public static LoadCombination ToLoadCombination(
             this IFBasicCombination lusasLoadCombination,
             Dictionary<string, Loadcase> bhomLoadcases)
         {

--- a/Lusas_Engine/Convert/ToBHoM/Loads/Loadcase.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/Loadcase.cs
@@ -27,7 +27,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static Loadcase ToBHoMLoadcase(this IFLoadcase lusasLoadcase)
+        public static Loadcase ToLoadcase(this IFLoadcase lusasLoadcase)
         {
             Loadcase BHoMLoadcase = new Loadcase { Name = Lusas.Query.GetName(lusasLoadcase),
                 Number = lusasLoadcase.getID()};

--- a/Lusas_Engine/Convert/ToBHoM/Loads/PointDisplacement.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/PointDisplacement.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Lusas
             IEnumerable<IFAssignment> lusasAssignments, Dictionary<string, Node> bhomNodeDictionary)
         {
             IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
-            Loadcase bhomLoadcase = ToBHoMLoadcase(assignedLoadcase);
+            Loadcase bhomLoadcase = ToLoadcase(assignedLoadcase);
 
             IEnumerable<Node> bhomNodes = Lusas.Query.GetNodeAssignments(lusasAssignments, bhomNodeDictionary);
 

--- a/Lusas_Engine/Convert/ToBHoM/Loads/PointLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/PointLoad.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Lusas
             Dictionary<string, Node> bhomNodeDictionary)
         {
             IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
-            Loadcase bhomLoadcase = ToBHoMLoadcase(assignedLoadcase);
+            Loadcase bhomLoadcase = ToLoadcase(assignedLoadcase);
 
             IEnumerable<Node> bhomNodes = Lusas.Query.GetNodeAssignments(lusasAssignments, bhomNodeDictionary);
 

--- a/Lusas_Engine/Convert/ToBHoM/Properties/Constraint4DOF.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/Constraint4DOF.cs
@@ -28,7 +28,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static Constraint4DOF ToBHoMConstraint4DOF(this IFSupportStructural lusasAttribute)
+        public static Constraint4DOF ToConstraint4DOF(this IFSupportStructural lusasAttribute)
         {
             List<string> releaseNames = new List<string> { "U", "V", "W", "THX" };
 

--- a/Lusas_Engine/Convert/ToBHoM/Properties/Constraint6DOF.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/Constraint6DOF.cs
@@ -28,7 +28,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static Constraint6DOF ToBHoMConstraint6DOF(this IFSupportStructural lusasAttribute)
+        public static Constraint6DOF ToConstraint6DOF(this IFSupportStructural lusasAttribute)
         {
             List<string> releaseNames = new List<string> { "U", "V", "W", "THX", "THY", "THZ" };
 

--- a/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
@@ -28,7 +28,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static IMaterialFragment ToBHoMMaterial(this IFAttribute lusasAttribute)
+        public static IMaterialFragment ToMaterial(this IFAttribute lusasAttribute)
         {
             string attributeName = Lusas.Query.GetName(lusasAttribute);
 

--- a/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/Material.cs
@@ -43,9 +43,6 @@ namespace BH.Engine.Lusas
                     ThermalExpansionCoeff = lusasAttribute.getValue("alpha"),
                     Density = lusasAttribute.getValue("rho")
                 };
-
-                Engine.Reflection.Compute.RecordWarning
-                ("Isotropic materials in Lusas will default to a GenericIsotropicMaterial");
             }
             else if (lusasAttribute is IFMaterialOrthotropic)
             {
@@ -56,9 +53,6 @@ namespace BH.Engine.Lusas
                     new Vector() { X = lusasAttribute.getValue("Gxy"), Y = 0.0, Z = 0.0 },
                     new Vector() { X = lusasAttribute.getValue("ax"), Y = lusasAttribute.getValue("ay"), Z = lusasAttribute.getValue("az") },
                     lusasAttribute.getValue("rho"), 0, 0);
-
-                Engine.Reflection.Compute.RecordWarning
-                    ("Orthotropic materials in Lusas will default to a TimberMaterial");
             }
 
             int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'M');

--- a/Lusas_Engine/Convert/ToBHoM/Properties/MeshSettings1D.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/MeshSettings1D.cs
@@ -28,7 +28,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static MeshSettings1D ToBHoMMeshSettings1D(this IFAttribute lusasAttrbute)
+        public static MeshSettings1D ToMeshSettings1D(this IFAttribute lusasAttrbute)
         {
             string attributeName = Lusas.Query.GetName(lusasAttrbute);
 

--- a/Lusas_Engine/Convert/ToBHoM/Properties/MeshSettings2D.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/MeshSettings2D.cs
@@ -27,7 +27,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static MeshSettings2D ToBHoMMeshSettings2D(this IFAttribute lusasAttribute)
+        public static MeshSettings2D ToMeshSettings2D(this IFAttribute lusasAttribute)
         {
             string attributeName = Lusas.Query.GetName(lusasAttribute);
             //object[] elementNames = lusasMeshSurface.getElementNames();

--- a/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
@@ -41,8 +41,8 @@ namespace BH.Engine.Lusas
                 double rgy = lusasAttribute.getValue("ky");
                 double rgz = lusasAttribute.getValue("kz");
                 double j = lusasAttribute.getValue("J");
-                double iz = lusasAttribute.getValue("Iyy");
-                double iy = lusasAttribute.getValue("Izz");
+                double iy = lusasAttribute.getValue("Iyy");
+                double iz = lusasAttribute.getValue("Izz");
                 double iw = lusasAttribute.getValue("Cw");
                 double wely = Math.Min(Math.Abs(lusasAttribute.getValue("Syt")), Math.Abs(lusasAttribute.getValue("Syb")));
                 double welz = Math.Min(Math.Abs(lusasAttribute.getValue("Szt")), Math.Abs(lusasAttribute.getValue("Szb")));

--- a/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
@@ -48,11 +48,11 @@ namespace BH.Engine.Lusas
                 double welz = Math.Min(Math.Abs(lusasAttribute.getValue("Szt")), Math.Abs(lusasAttribute.getValue("Szb")));
                 double wply = lusasAttribute.getValue("Zpy");
                 double wplz = lusasAttribute.getValue("Zpz");
-                double centreZ = lusasAttribute.getValue("zo");
-                double centreY = lusasAttribute.getValue("yo");
+                double centreZ = 0; //Eccentricity is handeled in the Bar not at the section
+                double centreY = 0; //Eccentricity is handeled in the Bar not at the section
                 double zt = lusasAttribute.getValue("zt");
-                double zb = Math.Abs(lusasAttribute.getValue("zb"));
-                double yt = Math.Abs(lusasAttribute.getValue("yb"));
+                double zb = Math.Abs(lusasAttribute.getValue("zb")); 
+                double yt = Math.Abs(lusasAttribute.getValue("yb")); //Lusas Y-Axis is opposite to the BHoM Y-axis
                 double yb = lusasAttribute.getValue("yt");
                 double asy = lusasAttribute.getValue("Asy");
                 double asz = lusasAttribute.getValue("Asz");

--- a/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
@@ -59,18 +59,16 @@ namespace BH.Engine.Lusas
 
                 bhomProfile = Engine.Structure.Compute.Integrate(bhomProfile, oM.Geometry.Tolerance.MicroDistance).Item1;
 
-            GenericSection bhomSection = new GenericSection(bhomProfile, area, rgy, rgz, j, iy, iz, iw,
+                GenericSection bhomSection = new GenericSection(bhomProfile, area, rgy, rgz, j, iy, iz, iw,
                     wely, welz, wply, wplz, centreZ, centreY, zt, zb, yt, yb, asy, asz);
 
                 bhomSection.Name = attributeName;
-
 
                 int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'G');
 
                 bhomSection.CustomData["Lusas_id"] = adapterID;
 
                 return bhomSection;
-            
 
         }
     }

--- a/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
@@ -29,45 +29,49 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
+      
         public static ISectionProperty ToBHoMSection(this IFAttribute lusasAttribute)
         {
             string attributeName = Lusas.Query.GetName(lusasAttribute);
-
+         
             IProfile bhomProfile = Lusas.Convert.ToProfile(lusasAttribute);
 
-            double area = lusasAttribute.getValue("A");
-            double rgy = lusasAttribute.getValue("ky");
-            double rgz = lusasAttribute.getValue("kz");
-            double j = lusasAttribute.getValue("J");
-            double iz = lusasAttribute.getValue("Iyy");
-            double iy = lusasAttribute.getValue("Izz");
-            double iw = lusasAttribute.getValue("Cw");
-            double wely = Math.Min(Math.Abs(lusasAttribute.getValue("Syt")), Math.Abs(lusasAttribute.getValue("Syb")));
-            double welz = Math.Min(Math.Abs(lusasAttribute.getValue("Szt")), Math.Abs(lusasAttribute.getValue("Szb")));
-            double wply = lusasAttribute.getValue("Zpy");
-            double wplz = lusasAttribute.getValue("Zpz");
-            double centreZ = lusasAttribute.getValue("zo");
-            double centreY = lusasAttribute.getValue("yo");
-            double zt = lusasAttribute.getValue("zt");
-            double zb = Math.Abs(lusasAttribute.getValue("zb"));
-            double yt = Math.Abs(lusasAttribute.getValue("yb"));
-            double yb = lusasAttribute.getValue("yt");
-            double asy = lusasAttribute.getValue("Asy");
-            double asz = lusasAttribute.getValue("Asz");
 
-            bhomProfile = Engine.Structure.Compute.Integrate(bhomProfile, oM.Geometry.Tolerance.MicroDistance).Item1;
+                double area = lusasAttribute.getValue("A");
+                double rgy = lusasAttribute.getValue("ky");
+                double rgz = lusasAttribute.getValue("kz");
+                double j = lusasAttribute.getValue("J");
+                double iz = lusasAttribute.getValue("Iyy");
+                double iy = lusasAttribute.getValue("Izz");
+                double iw = lusasAttribute.getValue("Cw");
+                double wely = Math.Min(Math.Abs(lusasAttribute.getValue("Syt")), Math.Abs(lusasAttribute.getValue("Syb")));
+                double welz = Math.Min(Math.Abs(lusasAttribute.getValue("Szt")), Math.Abs(lusasAttribute.getValue("Szb")));
+                double wply = lusasAttribute.getValue("Zpy");
+                double wplz = lusasAttribute.getValue("Zpz");
+                double centreZ = lusasAttribute.getValue("zo");
+                double centreY = lusasAttribute.getValue("yo");
+                double zt = lusasAttribute.getValue("zt");
+                double zb = Math.Abs(lusasAttribute.getValue("zb"));
+                double yt = Math.Abs(lusasAttribute.getValue("yb"));
+                double yb = lusasAttribute.getValue("yt");
+                double asy = lusasAttribute.getValue("Asy");
+                double asz = lusasAttribute.getValue("Asz");
 
-            SteelSection bhomSection = new SteelSection(
-                bhomProfile, area, rgy, rgz, j, iy, iz, iw,
-                wely, welz, wply, wplz, centreZ, centreY, zt, zb, yt, yb, asy, asz);
+                bhomProfile = Engine.Structure.Compute.Integrate(bhomProfile, oM.Geometry.Tolerance.MicroDistance).Item1;
 
-            bhomSection.Name = attributeName;
+            GenericSection bhomSection = new GenericSection(bhomProfile, area, rgy, rgz, j, iy, iz, iw,
+                    wely, welz, wply, wplz, centreZ, centreY, zt, zb, yt, yb, asy, asz);
 
-            int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'G');
+                bhomSection.Name = attributeName;
 
-            bhomSection.CustomData["Lusas_id"] = adapterID;
 
-            return bhomSection;
+                int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'G');
+
+                bhomSection.CustomData["Lusas_id"] = adapterID;
+
+                return bhomSection;
+            
+
         }
     }
 }

--- a/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/SectionProperty.cs
@@ -30,7 +30,7 @@ namespace BH.Engine.Lusas
     public static partial class Convert
     {
       
-        public static ISectionProperty ToBHoMSection(this IFAttribute lusasAttribute)
+        public static ISectionProperty ToSection(this IFAttribute lusasAttribute)
         {
             string attributeName = Lusas.Query.GetName(lusasAttribute);
          

--- a/Lusas_Engine/Convert/ToBHoM/Properties/SurfaceProperty.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/SurfaceProperty.cs
@@ -27,7 +27,7 @@ namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static ISurfaceProperty ToBHoMSurfaceProperty(this IFAttribute lusasAttribute)
+        public static ISurfaceProperty ToSurfaceProperty(this IFAttribute lusasAttribute)
         {
             string attributeName = Lusas.Query.GetName(lusasAttribute);
 

--- a/Lusas_Engine/Lusas_Engine.csproj
+++ b/Lusas_Engine/Lusas_Engine.csproj
@@ -135,7 +135,7 @@
     <Compile Include="Convert\ToBHoM\Loads\PointDisplacement.cs" />
     <Compile Include="Convert\ToBHoM\Properties\Constraint4DOF.cs" />
     <Compile Include="Convert\ToBHoM\Loads\LoadCombination.cs" />
-    <Compile Include="Convert\ToBHoM\Loads\PointForce.cs" />
+    <Compile Include="Convert\ToBHoM\Loads\PointLoad.cs" />
     <Compile Include="Convert\ToBHoM\Properties\SurfaceProperty.cs" />
     <Compile Include="Convert\ToBHoM\Properties\Constraint6DOF.cs" />
     <Compile Include="Convert\ToBHoM\Elements\Edge.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 

https://github.com/BHoM/BHoM/pull/654

<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #220 

<!-- Add short description of what has been fixed -->
- Added support for `TimberSection`, `ConcreteSection`, `AluminiumSection `and `GenericSection`
- Previously sections pulled from Lusas defaulted to `SteelSection`, with the addition of various Section, this will now default to` GenericSection`

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FLusas%5FToolkit%2FLusas%5FToolkit%2D%23220&sortField=Modified&isAscending=false&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added support for `TimberSection`, `ConcreteSection`, `AluminiumSection `and `GenericSection`
- Previously sections pulled from Lusas defaulted to `SteelSection`, with the addition of various Section, this will now default to` GenericSection`