### PR TITLE
Remove reference to "Lusas_id" in Lusas_Adapter and add AdapterIdName object in Lusas_Engine

### DIFF
--- a/Lusas_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -81,7 +81,7 @@ namespace BH.Adapter.Lusas
                         {
                             idsOut.Add(id);
                         }
-                        else if (o is IBHoMObject && (o as IBHoMObject).CustomData.TryGetValue("Lusas_id", out idObj) && int.TryParse(idObj.ToString(), out id))
+                        else if (o is IBHoMObject && (o as IBHoMObject).CustomData.TryGetValue(AdapterIdName, out idObj) && int.TryParse(idObj.ToString(), out id))
                             idsOut.Add(id);
                     }
                     return idsOut;
@@ -176,7 +176,7 @@ namespace BH.Adapter.Lusas
                     {
                         caseNums.Add(System.Convert.ToInt32(lCase.Item2.Number));
                     }
-                    caseNums.Add(System.Convert.ToInt32((lComb as LoadCombination).CustomData["Lusas_id"]));
+                    caseNums.Add(System.Convert.ToInt32((lComb as LoadCombination).CustomData[AdapterIdName]));
                 }
             }
 

--- a/Lusas_Engine/Convert/AdapterIdName.cs
+++ b/Lusas_Engine/Convert/AdapterIdName.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -20,39 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Collections.Generic;
-using System.Linq;
-using BH.oM.Structure.Elements;
-using BH.oM.Structure.Loads;
-using Lusas.LPI;
-
 namespace BH.Engine.Lusas
 {
     public static partial class Convert
     {
-        public static BarTemperatureLoad ToBarTemperatureLoad(
-            IFLoading lusasTemperatureLoad,
-            IEnumerable<IFAssignment> lusasAssignments,
-            Dictionary<string, Bar> bars)
-        {
-            IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
-            Loadcase bhomLoadcase = ToLoadcase(assignedLoadcase);
-            double temperatureChange = lusasTemperatureLoad.getValue("T")
-                - lusasTemperatureLoad.getValue("T0");
-
-            IEnumerable<Bar> bhomBars = Lusas.Query.GetLineAssignments(lusasAssignments, bars);
-            BarTemperatureLoad bhomBarTemperatureLoad = Structure.Create.BarTemperatureLoad(
-                bhomLoadcase,
-                temperatureChange,
-                bhomBars,
-                LoadAxis.Local,
-                false,
-                Lusas.Query.GetName(lusasTemperatureLoad));
-
-            int adapterID = Lusas.Query.GetAdapterID(lusasTemperatureLoad, 'l');
-            bhomBarTemperatureLoad.CustomData[AdapterIdName] = adapterID;
-            return bhomBarTemperatureLoad;
-        }
+        public const string AdapterIdName = "Lusas_id";
     }
 }
-

--- a/Lusas_Engine/Convert/ToBHoM/Elements/ToBar.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/ToBar.cs
@@ -100,7 +100,7 @@ namespace BH.Engine.Lusas
 
             string adapterID = Engine.Lusas.Modify.RemovePrefix(lusasLine.getName(), "L");
 
-            bhomBar.CustomData["Lusas_id"] = adapterID;
+            bhomBar.CustomData[AdapterIdName] = adapterID;
 
             return bhomBar;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Elements/ToEdge.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/ToEdge.cs
@@ -46,7 +46,7 @@ namespace BH.Engine.Lusas
 
             string adapterID = Engine.Lusas.Modify.RemovePrefix(lusasLine.getName(), "L");
 
-            bhomEdge.CustomData["Lusas_id"] = adapterID;
+            bhomEdge.CustomData[AdapterIdName] = adapterID;
 
             return bhomEdge;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Elements/ToNode.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/ToNode.cs
@@ -51,7 +51,7 @@ namespace BH.Engine.Lusas
             bhomNode.Tags = tags;
 
             string adapterID = Engine.Lusas.Modify.RemovePrefix(lusasPoint.getName(), "P");
-            bhomNode.CustomData["Lusas_id"] = adapterID;
+            bhomNode.CustomData[AdapterIdName] = adapterID;
 
             return bhomNode;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Elements/ToPanelPlanar.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Elements/ToPanelPlanar.cs
@@ -58,7 +58,7 @@ namespace BH.Engine.Lusas
             Panel bhomPanel = Structure.Create.Panel(surfaceEdges, dummyCurve);
 
             bhomPanel.Tags = tags;
-            bhomPanel.CustomData["Lusas_id"] = lusasSurface.getName();
+            bhomPanel.CustomData[AdapterIdName] = lusasSurface.getName();
 
             List<string> geometricAssignments = Lusas.Query.GetAttributeAssignments(lusasSurface, "Geometric");
             List<string> materialAssignments = Lusas.Query.GetAttributeAssignments(lusasSurface, "Material");

--- a/Lusas_Engine/Convert/ToBHoM/Loads/ToAreaTemperatureLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/ToAreaTemperatureLoad.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.Lusas
                 Lusas.Query.GetName(lusasTemperatureLoad));
 
             int adapterID = Lusas.Query.GetAdapterID(lusasTemperatureLoad, 'l');
-            bhomAreaTemperatureLoad.CustomData["Lusas_id"] = adapterID;
+            bhomAreaTemperatureLoad.CustomData[AdapterIdName] = adapterID;
 
             return bhomAreaTemperatureLoad;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Loads/ToAreaUniformlyDistributedLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/ToAreaUniformlyDistributedLoad.cs
@@ -72,7 +72,7 @@ namespace BH.Engine.Lusas
             }
 
             int adapterID = Lusas.Query.GetAdapterID(lusasDistributed, 'l');
-            bhomSurfaceUniformlyDistributed.CustomData["Lusas_id"] = adapterID;
+            bhomSurfaceUniformlyDistributed.CustomData[AdapterIdName] = adapterID;
 
             return bhomSurfaceUniformlyDistributed;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
@@ -86,7 +86,7 @@ namespace BH.Engine.Lusas
                 Lusas.Query.GetName(lusasBarDistributedLoad));
 
             int adapterID = Lusas.Query.GetAdapterID(lusasBarDistributedLoad, 'l');
-            bhomBarPointLoad.CustomData["Lusas_id"] = adapterID;
+            bhomBarPointLoad.CustomData[AdapterIdName] = adapterID;
 
             return bhomBarPointLoad;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Loads/ToBarPointLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/ToBarPointLoad.cs
@@ -67,7 +67,7 @@ namespace BH.Engine.Lusas
                 Lusas.Query.GetName(lusasBarPointLoad));
 
             int adapterID = Lusas.Query.GetAdapterID(lusasBarPointLoad, 'l');
-            bhomBarPointLoad.CustomData["Lusas_id"] = adapterID;
+            bhomBarPointLoad.CustomData[AdapterIdName] = adapterID;
 
             return bhomBarPointLoad;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Loads/ToBarUniformlyDistributedLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/ToBarUniformlyDistributedLoad.cs
@@ -79,7 +79,7 @@ namespace BH.Engine.Lusas
             }
 
             int adapterID = Lusas.Query.GetAdapterID(lusasDistributed, 'l');
-            bhomBarUniformlyDistributed.CustomData["Lusas_id"] = adapterID;
+            bhomBarUniformlyDistributed.CustomData[AdapterIdName] = adapterID;
 
             return bhomBarUniformlyDistributed;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Loads/ToGravityLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/ToGravityLoad.cs
@@ -52,7 +52,7 @@ namespace BH.Engine.Lusas
                 bhomLoadcase, gravityVector, bhomObjects, Lusas.Query.GetName(lusasGravityLoad));
 
             int adapterID = Lusas.Query.GetAdapterID(lusasGravityLoad, 'l');
-            bhomGravityLoad.CustomData["Lusas_id"] = adapterID;
+            bhomGravityLoad.CustomData[AdapterIdName] = adapterID;
 
             return bhomGravityLoad;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Loads/ToLoadCombination.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/ToLoadCombination.cs
@@ -58,7 +58,7 @@ namespace BH.Engine.Lusas
             };
 
             int adapterID = Lusas.Query.GetAdapterID(lusasLoadCombination, 'c');
-            BHoMLoadCombination.CustomData["Lusas_id"] = adapterID;
+            BHoMLoadCombination.CustomData[AdapterIdName] = adapterID;
 
             return BHoMLoadCombination;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Loads/ToLoadcase.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/ToLoadcase.cs
@@ -34,7 +34,7 @@ namespace BH.Engine.Lusas
 
             int adapterID = Lusas.Query.GetAdapterID(lusasLoadcase, 'c');
 
-            BHoMLoadcase.CustomData["Lusas_id"] = adapterID;
+            BHoMLoadcase.CustomData[AdapterIdName] = adapterID;
 
             return BHoMLoadcase;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Loads/ToPointDisplacement.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/ToPointDisplacement.cs
@@ -60,7 +60,7 @@ namespace BH.Engine.Lusas
                 Lusas.Query.GetName(lusasPrescribedDisplacement));
 
             int adapterID = Lusas.Query.GetAdapterID(lusasPrescribedDisplacement, 'd');
-            bhomPointDisplacement.CustomData["Lusas_id"] = adapterID;
+            bhomPointDisplacement.CustomData[AdapterIdName] = adapterID;
             // Needs to be a bit here that determines whether it is global or local - actually this cannot be done as the 
             //attribute is applied to a group, and within the group the axis could local or global
 

--- a/Lusas_Engine/Convert/ToBHoM/Loads/ToPointLoad.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Loads/ToPointLoad.cs
@@ -63,7 +63,7 @@ namespace BH.Engine.Lusas
                 Lusas.Query.GetName(lusasPointLoad));
 
             int adapterID = Lusas.Query.GetAdapterID(lusasPointLoad, 'l');
-            bhomPointLoad.CustomData["Lusas_id"] = adapterID;
+            bhomPointLoad.CustomData[AdapterIdName] = adapterID;
 
             return bhomPointLoad;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Properties/ToConstraint4DOF.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/ToConstraint4DOF.cs
@@ -73,7 +73,7 @@ namespace BH.Engine.Lusas
 
             int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'p');
 
-            bhomConstraint4DOF.CustomData["Lusas_id"] = adapterID;
+            bhomConstraint4DOF.CustomData[AdapterIdName] = adapterID;
 
             return bhomConstraint4DOF;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/ToConstraint6DOF.cs
@@ -63,7 +63,7 @@ namespace BH.Engine.Lusas
                attributeName, fixity, stiffness);
 
             int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'p');
-            bhomConstraint6DOF.CustomData["Lusas_id"] = adapterID;
+            bhomConstraint6DOF.CustomData[AdapterIdName] = adapterID;
 
             return bhomConstraint6DOF;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Properties/ToMaterial.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/ToMaterial.cs
@@ -56,7 +56,7 @@ namespace BH.Engine.Lusas
             }
 
             int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'M');
-            bhomMaterial.CustomData["Lusas_id"] = adapterID;
+            bhomMaterial.CustomData[AdapterIdName] = adapterID;
 
             return bhomMaterial;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Properties/ToMeshSettings1D.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/ToMeshSettings1D.cs
@@ -65,7 +65,7 @@ namespace BH.Engine.Lusas
             };
 
             int adapterID = Lusas.Query.GetAdapterID(lusasMeshLine, 'e');
-            bhomMeshSettings1D.CustomData["Lusas_id"] = adapterID;
+            bhomMeshSettings1D.CustomData[AdapterIdName] = adapterID;
 
             return bhomMeshSettings1D;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Properties/ToMeshSettings2D.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/ToMeshSettings2D.cs
@@ -75,7 +75,7 @@ namespace BH.Engine.Lusas
             };
 
             int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'e');
-            bhomMeshSettings2D.CustomData["Lusas_id"] = adapterID;
+            bhomMeshSettings2D.CustomData[AdapterIdName] = adapterID;
 
             return bhomMeshSettings2D;
         }

--- a/Lusas_Engine/Convert/ToBHoM/Properties/ToSectionProperty.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/ToSectionProperty.cs
@@ -66,7 +66,7 @@ namespace BH.Engine.Lusas
 
                 int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'G');
 
-                bhomSection.CustomData["Lusas_id"] = adapterID;
+                bhomSection.CustomData[AdapterIdName] = adapterID;
 
                 return bhomSection;
 

--- a/Lusas_Engine/Convert/ToBHoM/Properties/ToSurfaceProperty.cs
+++ b/Lusas_Engine/Convert/ToBHoM/Properties/ToSurfaceProperty.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Lusas
 
             int adapterID = Lusas.Query.GetAdapterID(lusasAttribute, 'G');
 
-            bhomProperty2D.CustomData["Lusas_id"] = adapterID;
+            bhomProperty2D.CustomData[AdapterIdName] = adapterID;
 
             return bhomProperty2D;
         }

--- a/Lusas_Engine/Lusas_Engine.csproj
+++ b/Lusas_Engine/Lusas_Engine.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Compute\SetSplitMethod.cs" />
     <Compile Include="Compute\CreateReleaseString.cs" />
     <Compile Include="Convert\Double.cs" />
+    <Compile Include="Convert\AdapterIdName.cs" />
     <Compile Include="Convert\ToBHoM\Properties\ToProfile.cs" />
     <Compile Include="Create\MeshSettings1D.cs" />
     <Compile Include="Query\CheckIllegalCharacters.cs" />

--- a/Lusas_Engine/Query/GetObjectIDs.cs
+++ b/Lusas_Engine/Query/GetObjectIDs.cs
@@ -55,7 +55,7 @@ namespace BH.Engine.Lusas
                         {
                             idsOut.Add(id);
                         }
-                        else if (o is IBHoMObject && (o as IBHoMObject).CustomData.TryGetValue("Lusas_id", out idObj) && int.TryParse(idObj.ToString(), out id))
+                        else if (o is IBHoMObject && (o as IBHoMObject).CustomData.TryGetValue(BH.Engine.Lusas.Convert.AdapterIdName, out idObj) && int.TryParse(idObj.ToString(), out id))
                             idsOut.Add(id);
                     }
                     return idsOut;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #231 

<!-- Add short description of what has been fixed -->
-Remove reference to `"Lusas_id"` in `Lusas_Adapter `and add `AdapterIdName` object in `Lusas_Engine`

### Test files
<!-- Link to test files to validate the proposed changes -->
https://github.com/BHoM/samples/blob/master/Structural_Adapters/Lusas_Toolkit/Workflows/Truss_Model.gh

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->