### PR TITLE
Fixed bug where "S" prefix from Lusas object name was being stored in Lusas_id for Panels

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Properties/LocalCoordinate.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/LocalCoordinate.cs
@@ -21,6 +21,7 @@
  */
 
 using System.Linq;
+using BH.Engine.Adapters.Lusas;
 using Lusas.LPI;
 
 namespace BH.Adapter.Lusas
@@ -77,7 +78,7 @@ namespace BH.Adapter.Lusas
                 worldZAxis.Zip(localZAxis, (d1,d2) => d1 * d2).Sum(),
             };
 
-            string customID = Engine.Adapters.Lusas.Modify.RemovePrefix(lusasLine.getName(), "L");
+            string customID = lusasLine.getName().RemovePrefix("L");
 
             string lusasName = "L" + customID + "/ Local Axis";
 

--- a/Lusas_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -30,6 +30,7 @@ using BH.oM.Data.Requests;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.Requests;
 using System.Linq;
+using BH.Engine.Adapters.Lusas;
 
 namespace BH.Adapter.Lusas
 {
@@ -104,7 +105,7 @@ namespace BH.Adapter.Lusas
                 {
                     ids.Add(
                         System.Convert.ToInt32(
-                        Engine.Adapters.Lusas.Modify.RemovePrefix(d_LusasData.getPointByNumber(i).getName(), "P")));
+                        d_LusasData.getPointByNumber(i).getName().RemovePrefix("P")));
                 }
             }
 
@@ -124,7 +125,7 @@ namespace BH.Adapter.Lusas
                 {
                     ids.Add(
                         System.Convert.ToInt32(
-                        Engine.Adapters.Lusas.Modify.RemovePrefix(d_LusasData.getLineByNumber(i).getName(), "L")));
+                        d_LusasData.getLineByNumber(i).getName().RemovePrefix("L")));
                 }
             }
 
@@ -144,7 +145,7 @@ namespace BH.Adapter.Lusas
                 {
                     ids.Add(
                         System.Convert.ToInt32(
-                        Engine.Adapters.Lusas.Modify.RemovePrefix(d_LusasData.getSurfaceByNumber(i).getName(), "S")));
+                        d_LusasData.getSurfaceByNumber(i).getName().RemovePrefix("S")));
                 }
             }
 

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/GetNode.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/GetNode.cs
@@ -21,6 +21,7 @@
  */
 
 using System.Collections.Generic;
+using BH.Engine.Adapters.Lusas;
 using BH.oM.Structure.Elements;
 using Lusas.LPI;
 
@@ -36,7 +37,7 @@ namespace BH.Adapter.Adapters.Lusas
         {
             Node bhomNode = null;
             IFPoint lusasPoint = lusasLine.getLOFs()[nodeIndex];
-            string pointName = Engine.Adapters.Lusas.Modify.RemovePrefix(lusasPoint.getName(), "P");
+            string pointName = lusasPoint.getName().RemovePrefix("P");
             bhomNodes.TryGetValue(pointName, out bhomNode);
 
             return bhomNode;

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToBar.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToBar.cs
@@ -31,6 +31,7 @@ using Lusas.LPI;
 using BH.oM.Adapters.Lusas;
 using System;
 using BH.Adapter.Lusas;
+using BH.Engine.Adapters.Lusas;
 
 namespace BH.Adapter.Adapters.Lusas
 {
@@ -106,7 +107,7 @@ namespace BH.Adapter.Adapters.Lusas
                 bhomBar.FEAType = barMeshProperties.Item4;
             }
 
-            string adapterID = Engine.Adapters.Lusas.Modify.RemovePrefix(lusasLine.getName(), "L");
+            string adapterID = lusasLine.getName().RemovePrefix("L");
 
             bhomBar.CustomData[AdapterIdName] = adapterID;
 

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToEdge.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToEdge.cs
@@ -25,6 +25,7 @@ using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
 using Lusas.LPI;
 using BH.Adapter.Lusas;
+using BH.Engine.Adapters.Lusas;
 
 namespace BH.Adapter.Adapters.Lusas
 {
@@ -49,7 +50,7 @@ namespace BH.Adapter.Adapters.Lusas
 
             Edge bhomEdge = new Edge { Curve = bhomLine, Tags = tags };
 
-            string adapterID = Engine.Adapters.Lusas.Modify.RemovePrefix(lusasLine.getName(), "L");
+            string adapterID = lusasLine.getName().RemovePrefix("L");
 
             bhomEdge.CustomData[AdapterIdName] = adapterID;
 

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToNode.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToNode.cs
@@ -27,6 +27,7 @@ using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
 using Lusas.LPI;
 using BH.Adapter.Lusas;
+using BH.Engine.Adapters.Lusas;
 
 namespace BH.Adapter.Adapters.Lusas
 {
@@ -55,7 +56,7 @@ namespace BH.Adapter.Adapters.Lusas
 
             bhomNode.Tags = tags;
 
-            string adapterID = Engine.Adapters.Lusas.Modify.RemovePrefix(lusasPoint.getName(), "P");
+            string adapterID = lusasPoint.getName().RemovePrefix("P");
             bhomNode.CustomData[AdapterIdName] = adapterID;
 
             return bhomNode;

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToPanelPlanar.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToPanelPlanar.cs
@@ -29,6 +29,7 @@ using BH.oM.Geometry;
 using BH.oM.Structure.MaterialFragments;
 using Lusas.LPI;
 using BH.Adapter.Lusas;
+using BH.Engine.Adapters.Lusas;
 
 namespace BH.Adapter.Adapters.Lusas
 {
@@ -63,7 +64,7 @@ namespace BH.Adapter.Adapters.Lusas
             Panel bhomPanel = Engine.Structure.Create.Panel(surfaceEdges, dummyCurve);
 
             bhomPanel.Tags = tags;
-            bhomPanel.CustomData[AdapterIdName] = lusasSurface.getName();
+            bhomPanel.CustomData[AdapterIdName] = lusasSurface.getName().RemovePrefix("S");
 
             List<string> geometricAssignments = GetAttributeAssignments(lusasSurface, "Geometric");
             List<string> materialAssignments = GetAttributeAssignments(lusasSurface, "Material");
@@ -94,7 +95,7 @@ namespace BH.Adapter.Adapters.Lusas
         {
             Edge bhomEdge = null;
             IFLine lusasEdge = lusasSurf.getLOFs()[lineIndex];
-            string lineName = Engine.Adapters.Lusas.Modify.RemovePrefix(lusasEdge.getName(), "L");
+            string lineName = lusasEdge.getName().RemovePrefix("L");
             bhomBars.TryGetValue(lineName, out bhomEdge);
             return bhomEdge;
         }

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/GetLineAssignments.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/GetLineAssignments.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using BH.oM.Structure.Elements;
 using Lusas.LPI;
 using BH.oM.Base;
+using BH.Engine.Adapters.Lusas;
 
 namespace BH.Adapter.Adapters.Lusas
 {
@@ -44,7 +45,7 @@ namespace BH.Adapter.Adapters.Lusas
                 if (lusasAssignment.getDatabaseObject() is IFLine)
                 {
                     IFLine lusasLine = (IFLine)lusasAssignment.getDatabaseObject();
-                    bhomBars.TryGetValue(Engine.Adapters.Lusas.Modify.RemovePrefix(lusasLine.getName(), "L"), out bhomBar);
+                    bhomBars.TryGetValue(lusasLine.getName().RemovePrefix("L"), out bhomBar);
                     assignedBars.Add(bhomBar);
                 }
                 else

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/GetPointAssignments.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/GetPointAssignments.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using BH.oM.Structure.Elements;
 using Lusas.LPI;
 using BH.oM.Base;
+using BH.Engine.Adapters.Lusas;
 
 namespace BH.Adapter.Adapters.Lusas
 {
@@ -44,7 +45,7 @@ namespace BH.Adapter.Adapters.Lusas
                 if (lusasAssignment.getDatabaseObject() is IFPoint)
                 {
                     IFPoint lusasPoint = (IFPoint)lusasAssignment.getDatabaseObject();
-                    bhomNodes.TryGetValue(Engine.Adapters.Lusas.Modify.RemovePrefix(lusasPoint.getName(), "P"), out bhomNode);
+                    bhomNodes.TryGetValue(lusasPoint.getName().RemovePrefix("P"), out bhomNode);
                     assignedNodes.Add(bhomNode);
                 }
                 else

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/GetSurfaceAssignments.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/GetSurfaceAssignments.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using BH.oM.Structure.Elements;
 using Lusas.LPI;
 using BH.oM.Base;
+using BH.Engine.Adapters.Lusas;
 
 namespace BH.Adapter.Adapters.Lusas
 {
@@ -44,7 +45,7 @@ namespace BH.Adapter.Adapters.Lusas
                 if (lusasAssignment.getDatabaseObject() is IFSurface)
                 {
                     IFSurface lusasSurface = (IFSurface)lusasAssignment.getDatabaseObject();
-                    bhomPanels.TryGetValue(Engine.Adapters.Lusas.Modify.RemovePrefix(lusasSurface.getName(), "S"), out bhomPanel);
+                    bhomPanels.TryGetValue(lusasSurface.getName().RemovePrefix("S"), out bhomPanel);
                     assignedSurfs.Add(bhomPanel);
                 }
                 else

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
@@ -28,6 +28,7 @@ using BH.oM.Structure.Loads;
 using BH.oM.Base;
 using Lusas.LPI;
 using BH.Adapter.Lusas;
+using BH.Engine.Adapters.Lusas;
 
 namespace BH.Adapter.Adapters.Lusas
 {
@@ -82,17 +83,17 @@ namespace BH.Adapter.Adapters.Lusas
 
                 if (lusasGeometry is IFPoint)
                 {
-                    bhomNodes.TryGetValue(Engine.Adapters.Lusas.Modify.RemovePrefix(lusasGeometry.getName(), "P"), out bhomNode);
+                    bhomNodes.TryGetValue(lusasGeometry.getName().RemovePrefix("P"), out bhomNode);
                     assignedObjects.Add(bhomNode);
                 }
                 else if (lusasGeometry is IFLine)
                 {
-                    bhomBars.TryGetValue(Engine.Adapters.Lusas.Modify.RemovePrefix(lusasGeometry.getName(), "L"), out bhomBar);
+                    bhomBars.TryGetValue(lusasGeometry.getName().RemovePrefix("L"), out bhomBar);
                     assignedObjects.Add(bhomBar);
                 }
                 else if (lusasGeometry is IFSurface)
                 {
-                    bhomPanels.TryGetValue(Engine.Adapters.Lusas.Modify.RemovePrefix(lusasGeometry.getName(), "S"), out bhomPanel);
+                    bhomPanels.TryGetValue(lusasGeometry.getName().RemovePrefix("S"), out bhomPanel);
                     assignedObjects.Add(bhomPanel);
                 }
             }

--- a/Lusas_Adapter/Type/NextFreeId.cs
+++ b/Lusas_Adapter/Type/NextFreeId.cs
@@ -31,7 +31,7 @@ using BH.oM.Structure.Loads;
 using BH.oM.Geometry;
 using Lusas.LPI;
 using BH.oM.Adapters.Lusas;
-
+using BH.Engine.Adapters.Lusas;
 
 namespace BH.Adapter.Lusas
 {
@@ -74,7 +74,7 @@ namespace BH.Adapter.Lusas
 
                         IFPoint largestPoint = d_LusasData.getPointByNumber(largestPointID);
                         index = System.Convert.ToInt32(
-                               Engine.Adapters.Lusas.Modify.RemovePrefix(largestPoint.getName(), "P")) + 1;
+                               largestPoint.getName().RemovePrefix("P")) + 1;
                     }
                 }
                 if (type == typeof(Bar))
@@ -88,7 +88,7 @@ namespace BH.Adapter.Lusas
 
                         IFLine largestLine = d_LusasData.getLineByNumber(d_LusasData.getLargestLineID());
                         index = System.Convert.ToInt32(
-                               Engine.Adapters.Lusas.Modify.RemovePrefix(largestLine.getName(), "L")) + 1;
+                               largestLine.getName().RemovePrefix("L")) + 1;
                     }
                 }
                 if (type == typeof(Panel))
@@ -102,7 +102,7 @@ namespace BH.Adapter.Lusas
 
                         IFSurface largestSurface = d_LusasData.getSurfaceByNumber(d_LusasData.getLargestSurfaceID());
                         index = System.Convert.ToInt32(
-                            Engine.Adapters.Lusas.Modify.RemovePrefix(largestSurface.getName(), "S")) + 1;
+                            largestSurface.getName().RemovePrefix("S")) + 1;
                     }
                 }
                 if (type == typeof(Edge))
@@ -116,7 +116,7 @@ namespace BH.Adapter.Lusas
 
                         IFLine largestLine = d_LusasData.getLineByNumber(d_LusasData.getLargestLineID());
                         index = System.Convert.ToInt32(
-                            Engine.Adapters.Lusas.Modify.RemovePrefix(largestLine.getName(), "L")) + 1;
+                            largestLine.getName().RemovePrefix("L")) + 1;
                     }
                 }
                 if (type == typeof(Point))
@@ -131,7 +131,7 @@ namespace BH.Adapter.Lusas
 
                         IFPoint largestPoint = d_LusasData.getPointByNumber(largestPointID);
                         index = System.Convert.ToInt32(
-                            Engine.Adapters.Lusas.Modify.RemovePrefix(largestPoint.getName(), "P")) + 1;
+                            largestPoint.getName().RemovePrefix("P")) + 1;
                     }
                 }
                 if (typeof(ICase).IsAssignableFrom(type))

--- a/Lusas_Engine/Modify/RemovePrefix.cs
+++ b/Lusas_Engine/Modify/RemovePrefix.cs
@@ -28,7 +28,7 @@ namespace BH.Engine.Adapters.Lusas
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static string RemovePrefix(string name, string forRemoval)
+        public static string RemovePrefix(this string name, string forRemoval)
         {
             string adapterID = "";
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ https://www.lusas.com/
 
 ### Known Versions of Software Supported
 Lusas Modeller v17
-
 Lusas Modeller v18
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ https://www.lusas.com/
 
 ### Known Versions of Software Supported
 Lusas Modeller v17
+
 Lusas Modeller v18
 
 ### Documentation


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #257 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/Evvr4sX2YNxOkDTXxfq4UDABZ4h--XBrl_ss2uAbxdXHcw?e=6nOZj1

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
Make sure you build Debug18 so the DLL is updated, Visual Studio defaults to Debug17.