### PR TITLE
Implement DescriptionOrName comparer

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
 using Lusas.LPI;
+using BH.Engine.Structure;
 
 namespace BH.Adapter.Lusas
 {
@@ -39,13 +40,13 @@ namespace BH.Adapter.Lusas
 
         private IFAttribute CreateGeometricLine(ISectionProperty sectionProperty)
         {
-            if (!Engine.Adapters.Lusas.Query.CheckIllegalCharacters(sectionProperty.Name))
+            if (!Engine.Adapters.Lusas.Query.CheckIllegalCharacters(sectionProperty.DescriptionOrName()))
             {
                 return null;
             }
 
             IFAttribute lusasAttribute = null;
-            string lusasName = "G" + sectionProperty.CustomData[AdapterIdName] + "/" + sectionProperty.Name;
+            string lusasName = "G" + sectionProperty.CustomData[AdapterIdName] + "/" + sectionProperty.DescriptionOrName();
 
             if (d_LusasData.existsAttribute("Line Geometric", lusasName))
             {

--- a/Lusas_Adapter/CRUD/Create/Properties/GeometricSurface.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/GeometricSurface.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Structure;
 using BH.oM.Structure.SurfaceProperties;
 using Lusas.LPI;
 
@@ -37,13 +38,13 @@ namespace BH.Adapter.Lusas
 
         private IFAttribute CreateGeometricSurface(ISurfaceProperty surfaceProperty)
         {
-            if (!Engine.Adapters.Lusas.Query.CheckIllegalCharacters(surfaceProperty.Name))
+            if (!Engine.Adapters.Lusas.Query.CheckIllegalCharacters(surfaceProperty.DescriptionOrName()))
             {
                 return null;
             }
 
             IFAttribute lusasAttribute = null;
-            string lusasName = "G" + surfaceProperty.CustomData[AdapterIdName] + "/" + surfaceProperty.Name;
+            string lusasName = "G" + surfaceProperty.CustomData[AdapterIdName] + "/" + surfaceProperty.DescriptionOrName();
 
             if (d_LusasData.existsAttribute("Surface Geometric", lusasName))
             {

--- a/Lusas_Adapter/CRUD/Create/Properties/Material.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Material.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Reflection;
+using BH.Engine.Structure;
 using BH.oM.Structure.MaterialFragments;
 using Lusas.LPI;
 
@@ -43,7 +45,7 @@ namespace BH.Adapter.Lusas
             }
 
             IFAttribute lusasMaterial = null;
-            string lusasName = "M" + material.CustomData[AdapterIdName] + "/" + material.Name;
+            string lusasName = "M" + material.CustomData[AdapterIdName] + "/" + material.DescriptionOrName();
 
             if (material is IIsotropic)
             {

--- a/Lusas_Adapter/CRUD/Create/Properties/Support.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/Support.cs
@@ -40,13 +40,13 @@ namespace BH.Adapter.Lusas
 
         private IFAttribute CreateSupport(Constraint6DOF constraint)
         {
-            if (!Engine.Adapters.Lusas.Query.CheckIllegalCharacters(constraint.Name))
+            if (!Engine.Adapters.Lusas.Query.CheckIllegalCharacters(constraint.DescriptionOrName()))
             {
                 return null;
             }
 
             IFAttribute lusasSupport = null;
-            string lusasName = "Sp" + constraint.CustomData[AdapterIdName] + "/" + constraint.Name;
+            string lusasName = "Sp" + constraint.CustomData[AdapterIdName] + "/" + constraint.DescriptionOrName();
 
             if (d_LusasData.existsAttribute("Support", lusasName))
             {
@@ -90,13 +90,13 @@ namespace BH.Adapter.Lusas
 
         private IFAttribute CreateSupport(Constraint4DOF constraint)
         {
-            if (!Engine.Adapters.Lusas.Query.CheckIllegalCharacters(constraint.Name))
+            if (!Engine.Adapters.Lusas.Query.CheckIllegalCharacters(constraint.DescriptionOrName()))
             {
                 return null;
             }
 
             IFAttribute lusasSupport = null;
-            string lusasName = "Sp" + constraint.CustomData[AdapterIdName] + "/" + constraint.Name;
+            string lusasName = "Sp" + constraint.CustomData[AdapterIdName] + "/" + constraint.DescriptionOrName();
 
             if (d_LusasData.existsAttribute("Support", lusasName))
             {

--- a/Lusas_Adapter/LusasAdapter.cs
+++ b/Lusas_Adapter/LusasAdapter.cs
@@ -24,6 +24,7 @@
 using BH.Engine.Base.Objects;
 using BH.oM.Adapter;
 using BH.oM.Adapters.Lusas;
+using BH.Engine.Structure;
 using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Constraints;
@@ -65,10 +66,11 @@ namespace BH.Adapter.Lusas
                     {typeof(Bar), new Engine.Adapters.Lusas.Object_Comparer.Equality_Comparer.BarMidPointComparer(3)},
                     {typeof(Edge), new Engine.Adapters.Lusas.Object_Comparer.Equality_Comparer.EdgeMidPointComparer(3) },
                     { typeof(Point), new Engine.Adapters.Lusas.Object_Comparer.Equality_Comparer.PointDistanceComparer(3) },
-                    {typeof(IMaterialFragment), new BHoMObjectNameComparer() },
-                    {typeof(LinkConstraint), new BHoMObjectNameComparer() },
-                    {typeof(ISurfaceProperty), new BHoMObjectNameComparer() },
-                    {typeof(ISectionProperty), new BHoMObjectNameComparer() },
+                    {typeof(IMaterialFragment), new NameOrDescriptionComparer() },
+                    {typeof(LinkConstraint), new NameOrDescriptionComparer() },
+                    {typeof(ISurfaceProperty), new NameOrDescriptionComparer() },
+                    {typeof(ISectionProperty), new NameOrDescriptionComparer() },
+                    {typeof(Constraint6DOF), new NameOrDescriptionComparer() },
                     {typeof(ILoad), new BHoMObjectNameComparer() },
                     {typeof(Loadcase), new BHoMObjectNameComparer()},
                     {typeof(LoadCombination), new BHoMObjectNameComparer()}
@@ -103,7 +105,7 @@ namespace BH.Adapter.Lusas
                     {
                         d_LusasData = m_LusasApplication.openDatabase(filePath);
                     }
-                    catch(System.Runtime.InteropServices.COMException)
+                    catch (System.Runtime.InteropServices.COMException)
                     {
                         throw new Exception("An exception has been flagged by Lusas, it is likely the file is from a higher version of Lusas than the adapter being used.");
                     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #252 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EjVJ8CFp1xBJupSvT4I7ugIBskjCQG7Qgar_OPEUDvmQ2Q?e=Fv0ggY

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
The Name of properties is not being reflected back to the objects, so when a `Bar` is pushed with a `SectionProperty` and `Material`, it is not being retrieved because the `Name` is still empty.
![image](https://user-images.githubusercontent.com/30078587/83188749-161d3c80-a128-11ea-905e-17ac61a2e9c2.png)

![image](https://user-images.githubusercontent.com/30078587/83188809-259c8580-a128-11ea-9498-6fff81053df0.png)
 