### PR TITLE
Various bug fixes for reading Loads

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
@@ -96,7 +96,7 @@ namespace BH.Adapter.Lusas
                     if ((valueAtA != 0) || (valueAtB != 0))
                     {
                         IFLoadingBeamDistributed lusasBarDistributedLoad =
-                            d_LusasData.createLoadingBeamDistributed(bhomBarDistributedLoad.Name + key);
+                            d_LusasData.createLoadingBeamDistributed(lusasName + key);
 
                         if (bhomBarDistributedLoad.Axis.ToString() == "Global")
                             lusasBarDistributedLoad.setBeamDistributed("parametric", "global", "beam");

--- a/Lusas_Adapter/CRUD/Create/Loads/BarPointLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/BarPointLoad.cs
@@ -58,7 +58,7 @@ namespace BH.Adapter.Lusas
             }
             else
             {
-                lusasBarPointLoad = d_LusasData.createLoadingBeamPoint(bhomBarPointLoad.Name);
+                lusasBarPointLoad = d_LusasData.createLoadingBeamPoint(lusasName);
                 if (bhomBarPointLoad.Axis.ToString() == "Global")
                     lusasBarPointLoad.setBeamPoint("parametric", "global", "beam");
                 else

--- a/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
@@ -232,10 +232,10 @@ namespace BH.Adapter.Lusas
             lusasGeometricLine.setValue("elementType", "3D Thick Beam");
 
             List<double> dimensionList = new List<double> { bhomProfile.Height, bhomProfile.Width,
-            bhomProfile.WebThickness, bhomProfile.FlangeThickness, bhomProfile.RootRadius};
+            bhomProfile.FlangeThickness, bhomProfile.WebThickness, bhomProfile.RootRadius};
             double[] dimensionArray = dimensionList.ToArray();
 
-            List<string> valueList = new List<string> { "D", "B", "tw", "tf", "r" };
+            List<string> valueList = new List<string> { "D", "B", "tf", "tw", "r" };
             string[] valueArray = valueList.ToArray();
 
             int lusasType = 5;

--- a/Lusas_Adapter/CRUD/Read/Loads/AreaTemperatureLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/AreaTemperatureLoads.cs
@@ -43,7 +43,7 @@ namespace BH.Adapter.Lusas
             List<ILoad> bhomAreaTemperatureLoads = new List<ILoad>();
             object[] lusasTemperatureLoads = d_LusasData.getAttributes("Temperature");
 
-            if (!(bhomAreaTemperatureLoads.Count() == 0))
+            if (!(lusasTemperatureLoads.Count() == 0))
             {
                 List<Panel> bhomPanel = ReadPanels();
                 Dictionary<string, Panel> surfaceDictionary = bhomPanel.ToDictionary(

--- a/Lusas_Adapter/CRUD/Read/Loads/GravityLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/GravityLoads.cs
@@ -45,11 +45,13 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasBodyForces.Count() == 0))
             {
+                List<Node> bhomNodes = ReadNodes();
                 List<Bar> bhomBars = ReadBars();
                 List<Panel> bhomPanels = ReadPanels();
+                Dictionary<string, Node> nodeDictionary = bhomNodes.ToDictionary(
+                    x => x.CustomData[AdapterIdName].ToString());
                 Dictionary<string, Bar> barDictionary = bhomBars.ToDictionary(
                     x => x.CustomData[AdapterIdName].ToString());
-
                 Dictionary<string, Panel> PanelDictionary = bhomPanels.ToDictionary(
                     x => x.CustomData[AdapterIdName].ToString());
 
@@ -67,7 +69,7 @@ namespace BH.Adapter.Lusas
                         List<string> analysisName = new List<string> { lusasBodyForce.getAttributeType() };
 
                         GravityLoad bhomGravityLoad = Adapters.Lusas.Convert.ToGravityLoad(
-                            lusasBodyForce, groupedAssignment, barDictionary, PanelDictionary);
+                            lusasBodyForce, groupedAssignment, nodeDictionary, barDictionary, PanelDictionary);
                         bhomGravityLoad.Tags = new HashSet<string>(analysisName);
                         bhomGravityLoads.Add(bhomGravityLoad);
                     }

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
@@ -40,6 +40,7 @@ namespace BH.Adapter.Adapters.Lusas
 
         public static GravityLoad ToGravityLoad(IFLoading lusasGravityLoad,
             IEnumerable<IFAssignment> lusasAssignments,
+            Dictionary<string, Node> bhomNodes,
             Dictionary<string, Bar> bhomBars,
             Dictionary<string, Panel> bhomPanels)
         {
@@ -53,7 +54,7 @@ namespace BH.Adapter.Adapters.Lusas
             };
 
             IEnumerable<BHoMObject> bhomObjects = GetGeometryAssignments(
-                lusasAssignments, null, bhomBars, bhomPanels);
+                lusasAssignments, bhomNodes, bhomBars, bhomPanels);
             GravityLoad bhomGravityLoad = Engine.Structure.Create.GravityLoad(
                 bhomLoadcase, gravityVector, bhomObjects, GetName(lusasGravityLoad));
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #264 
Closes #265 
Closes #266 
Closes #267 

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/Ejkc4lshGMlBjzjXV4HPUaIB6ql8IlMk9x-_TKz5HgKn7g?e=cOcAi6

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed bug where `Node`s were not being read for `GravityLoad`
- Fixed bug where `BarDistributedLoad` and `BarPointLoad` did not follow the Lusas naming convention and presented problems when pulling the loads  
- Fixed bug where the `FlangeThickness` and `WebThickness` were switched for an `ISection` when being pulled
- Fixed bug where `AreaTemperatureLoad`s were not being read 

### Additional comments
<!-- As required -->
@JKarasinska can you test on Lusas 170 please.
@StephennipBH can you test on Lusas 180 please.

From the script you should be able to:
1. Push the `Element`s to your version of Lusas
2. Push the `Load`s to Lusas
3. Read the `Load`s from Lusas