### PR TITLE
Update dependency types for Edge to allow supports and releases to be pushed

### DIFF
--- a/Lusas_Adapter/LusasAdapter.cs
+++ b/Lusas_Adapter/LusasAdapter.cs
@@ -83,6 +83,7 @@ namespace BH.Adapter.Lusas
                 DependencyTypes = new Dictionary<Type, List<Type>>
                 {
                     {typeof(Panel), new List<Type> { typeof(ISurfaceProperty), typeof(Edge)} },
+                    {typeof(Edge), new List<Type> { typeof(Constraint4DOF), typeof(Constraint6DOF) } },
                     {typeof(Bar), new List<Type> { typeof(Node) , typeof(ISectionProperty), typeof(Constraint4DOF) } },
                     {typeof(Node), new List<Type> { typeof(Constraint6DOF) } },
                     {typeof(ISectionProperty), new List<Type> { typeof(IMaterialFragment) } },


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #316 
Closes #317 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[To check `Edge` and their supports are pushed.](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/Installers/Scripts/BuroHappold_BHoM_v4.1/Structures%20-%20Create%20-%20Read%20-%20Update%20-%20Elements/BuroHappold_BHoM_v4.1.beta_Create%20-%20read%20-%20update%20elements%20-%20building.gh?csf=1&web=1&e=YjcAVO)
[Push `Panel` objects and their dependicies](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/Installers/Scripts/BuroHappold_BHoM_v4.2/Structures%20-%20Create%20-%20Read%20-%20Update%20-%20Elements/BuroHappold_BHoM_v4.2.beta_Create%20-%20read%20-%20elements%20-%20bridges.gh?csf=1&web=1&e=J5UaJg)
[Null object test data - to check `null` handling still works correctly](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/Archive/Lusas_Toolkit/Lusas_Toolkit-%23290?csf=1&web=1&e=RoNToj)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed bug where supports for `Edge`s were not being pushed
- Refactored creation of `Panel` to simplify checks and make use of `Edge` being a dependency type