### PR TITLE
Add error message when trying to Save after creating a new model

### DIFF
--- a/Lusas_Adapter/AdapterActions/Execute.cs
+++ b/Lusas_Adapter/AdapterActions/Execute.cs
@@ -74,6 +74,12 @@ namespace BH.Adapter.Lusas
 
         public bool RunCommand(Save command)
         {
+            if (d_LusasData.getDBFilename() == "")
+            {
+                Engine.Reflection.Compute.RecordError("The model file does not have a filename, please SaveAs before attempting to Save.");
+                return false;
+            }
+
             d_LusasData.save();
 
             return true;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #319 

<!-- Add short description of what has been fixed -->
- Added an error message when a user attempts to `Save` straight after creating a `NewModel`, instead instructing the user to `SaveAs` the model first.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/Installers/Scripts/BuroHappold_BHoM_v4.2/Structures%20-%20Execute%20commands?csf=1&web=1&e=W4HMEb

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->