### PR TITLE
Delete sections CSV file when NewModel command is executed to allow PushPullCompare to run without warning

### DIFF
--- a/Lusas_Adapter/AdapterActions/Execute.cs
+++ b/Lusas_Adapter/AdapterActions/Execute.cs
@@ -21,6 +21,7 @@
  */
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using BH.Engine.Adapter;
 using BH.oM.Adapters.Lusas;
@@ -66,6 +67,9 @@ namespace BH.Adapter.Lusas
             d_LusasData.setVerticalDir("Z");
             m_LusasApplication.fileOpen("%PerMachineAppDataPlatform%\\config\\AfterNewModel");
             d_LusasData.setAnalysisCategory("3D");
+
+            string fileName = @"sections.csv";
+            File.Delete(fileName);
 
             return true;
         }

--- a/Lusas_Adapter/AdapterActions/Execute.cs
+++ b/Lusas_Adapter/AdapterActions/Execute.cs
@@ -68,7 +68,7 @@ namespace BH.Adapter.Lusas
             m_LusasApplication.fileOpen("%PerMachineAppDataPlatform%\\config\\AfterNewModel");
             d_LusasData.setAnalysisCategory("3D");
 
-            string fileName = @"sections.csv";
+            string fileName = $"{m_directory}\\sections.csv";
             File.Delete(fileName);
 
             return true;

--- a/Lusas_Adapter/LusasAdapter.cs
+++ b/Lusas_Adapter/LusasAdapter.cs
@@ -36,6 +36,7 @@ using Lusas.LPI;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 namespace BH.Adapter.Lusas
 {
@@ -60,6 +61,7 @@ namespace BH.Adapter.Lusas
         {
             if (active)
             {
+                m_directory = new FileInfo(filePath).Directory.FullName;
                 AdapterIdFragmentType = typeof(LusasId);
 
                 BH.Adapter.Modules.Structure.ModuleLoader.LoadModules(this);
@@ -135,6 +137,7 @@ namespace BH.Adapter.Lusas
 
         //Add any comlink object as a private field here, example named:
 
+        private string m_directory;
         public LusasWinApp m_LusasApplication;
         public IFDatabase d_LusasData;
         private Dictionary<Type, Dictionary<int, HashSet<string>>> m_tags = new Dictionary<Type, Dictionary<int, HashSet<string>>>();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Closes #324 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Removes sections.csv file before creating a new model](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/Archive/Lusas_Toolkit/Lusas_Toolkit-%23324?csf=1&web=1&e=cRDWFs)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Delete `sections.csv` from the directory where the model file is saved when `NewModel` command is executed
- This is primarily to allow the `PushPullCompare` to run without raising a warning 
