### PR TITLE
Lusas_Toolkit: Make use of caching system in BHoM Adapter

### DIFF
--- a/Lusas_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Bars.cs
@@ -54,25 +54,20 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasLines.Count() == 0))
             {
-                IEnumerable<Node> nodesList = ReadNodes();
-                Dictionary<string, Node> nodes = nodesList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                IEnumerable<Node> nodesList = GetCachedOrRead<Node>();
+                Dictionary<string, Node> nodes = nodesList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
-                IEnumerable<Constraint4DOF> supportsList = Read4DOFConstraints();
-                Dictionary<string, Constraint4DOF> supports = supportsList.ToDictionary(
-                    x => x.Name);
+                IEnumerable<Constraint4DOF> supportsList = GetCachedOrRead<Constraint4DOF>();
+                Dictionary<string, Constraint4DOF> supports = supportsList.ToDictionary(x => x.Name);
 
-                IEnumerable<IMaterialFragment> materialList = ReadMaterials();
-                Dictionary<string, IMaterialFragment> materials = materialList.ToDictionary(
-                    x => x.Name.ToString());
+                IEnumerable<IMaterialFragment> materialList = GetCachedOrRead<IMaterialFragment>();
+                Dictionary<string, IMaterialFragment> materials = materialList.ToDictionary(x => x.Name.ToString());
 
-                IEnumerable<ISectionProperty> sectionPropertiesList = ReadSectionProperties();
-                Dictionary<string, ISectionProperty> sectionProperties = sectionPropertiesList.ToDictionary(
-                    x => x.Name.ToString());
+                IEnumerable<ISectionProperty> sectionPropertiesList = GetCachedOrRead<ISectionProperty>();
+                Dictionary<string, ISectionProperty> sectionProperties = sectionPropertiesList.ToDictionary(x => x.Name.ToString());
 
-                List<MeshSettings1D> meshesList = ReadMeshSettings1D();
-                Dictionary<string, MeshSettings1D> meshes = meshesList.ToDictionary(
-                    x => x.Name.ToString());
+                List<MeshSettings1D> meshesList = GetCachedOrRead<MeshSettings1D>();
+                Dictionary<string, MeshSettings1D> meshes = meshesList.ToDictionary(x => x.Name.ToString());
 
                 HashSet<string> groupNames = ReadTags();
 

--- a/Lusas_Adapter/CRUD/Read/Elements/Edges.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Edges.cs
@@ -50,9 +50,8 @@ namespace BH.Adapter.Lusas
 
             if (lusasLines.Count() != 0)
             {
-                List<Node> nodesList = ReadNodes();
-                Dictionary<string, Node> nodes = nodesList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                List<Node> nodesList = GetCachedOrRead<Node>();
+                Dictionary<string, Node> nodes = nodesList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 HashSet<string> groupNames = ReadTags();
 

--- a/Lusas_Adapter/CRUD/Read/Elements/Nodes.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Nodes.cs
@@ -51,9 +51,8 @@ namespace BH.Adapter.Lusas
             {
                 HashSet<string> groupNames = ReadTags();
 
-                IEnumerable<Constraint6DOF> constraints6DOFList = Read6DOFConstraints();
-                Dictionary<string, Constraint6DOF> constraints6DOF = constraints6DOFList.ToDictionary(
-                    x => x.Name.ToString());
+                IEnumerable<Constraint6DOF> constraints6DOFList = GetCachedOrRead<Constraint6DOF>();
+                Dictionary<string, Constraint6DOF> constraints6DOF = constraints6DOFList.ToDictionary(x => x.Name.ToString());
 
                 for (int i = 0; i < lusasPoints.Count(); i++)
                 {

--- a/Lusas_Adapter/CRUD/Read/Elements/Panels.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Panels.cs
@@ -54,26 +54,22 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasSurfaces.Count() == 0))
             {
-                IEnumerable<Edge> edgesList = ReadEdges();
-                Dictionary<string, Edge> edges = edgesList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                IEnumerable<Edge> edgesList = GetCachedOrRead<Edge>();
+                Dictionary<string, Edge> edges = edgesList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 HashSet<string> groupNames = ReadTags();
-                IEnumerable<IMaterialFragment> materialList = ReadMaterials();
-                Dictionary<string, IMaterialFragment> materials = materialList.ToDictionary(
-                    x => x.Name.ToString());
 
-                IEnumerable<ISurfaceProperty> sectionPropertiesList = Read2DProperties();
-                Dictionary<string, ISurfaceProperty> sectionProperties = sectionPropertiesList.ToDictionary(
-                    x => x.Name.ToString());
+                IEnumerable<IMaterialFragment> materialList = GetCachedOrRead<IMaterialFragment>();
+                Dictionary<string, IMaterialFragment> materials = materialList.ToDictionary(x => x.Name.ToString());
 
-                IEnumerable<Constraint4DOF> supportsList = Read4DOFConstraints();
-                Dictionary<string, Constraint4DOF> supports = supportsList.ToDictionary(
-                    x => x.Name);
+                IEnumerable<ISurfaceProperty> sectionPropertiesList = GetCachedOrRead<ISurfaceProperty>();
+                Dictionary<string, ISurfaceProperty> sectionProperties = sectionPropertiesList.ToDictionary(x => x.Name.ToString());
 
-                List<MeshSettings2D> meshesList = ReadMeshSettings2D();
-                Dictionary<string, MeshSettings2D> meshes = meshesList.ToDictionary(
-                    x => x.Name.ToString());
+                IEnumerable<Constraint4DOF> supportsList = GetCachedOrRead<Constraint4DOF>();
+                Dictionary<string, Constraint4DOF> supports = supportsList.ToDictionary(x => x.Name);
+
+                List<MeshSettings2D> meshesList = GetCachedOrRead<MeshSettings2D>();
+                Dictionary<string, MeshSettings2D> meshes = meshesList.ToDictionary(x => x.Name.ToString());
 
                 for (int i = 0; i < lusasSurfaces.Count(); i++)
                 {

--- a/Lusas_Adapter/CRUD/Read/Loads/AreaUniformTemperatureLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/AreaUniformTemperatureLoads.cs
@@ -51,9 +51,8 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasTemperatureLoads.Count() == 0))
             {
-                List<Panel> panelsList = ReadPanels();
-                Dictionary<string, Panel> panels = panelsList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                List<Panel> panelsList = GetCachedOrRead<Panel>();
+                Dictionary<string, Panel> panels = panelsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 

--- a/Lusas_Adapter/CRUD/Read/Loads/AreaUniformlyDistributedLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/AreaUniformlyDistributedLoads.cs
@@ -57,9 +57,8 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasDistributedLoads.Count() == 0))
             {
-                List<Panel> panelsList = ReadPanels();
-                Dictionary<string, Panel> panels = panelsList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                List<Panel> panelsList = GetCachedOrRead<Panel>();
+                Dictionary<string, Panel> panels = panelsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 

--- a/Lusas_Adapter/CRUD/Read/Loads/BarPointLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/BarPointLoads.cs
@@ -52,9 +52,8 @@ namespace BH.Adapter.Lusas
 
             if (lusasInternalBeamPointLoads.Count() != 0)
             {
-                List<Bar> barsList = ReadBars();
-                Dictionary<string, Bar> bars = barsList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                List<Bar> barsList = GetCachedOrRead<Bar>();
+                Dictionary<string, Bar> bars = barsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 

--- a/Lusas_Adapter/CRUD/Read/Loads/BarUniformTemperatureLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/BarUniformTemperatureLoads.cs
@@ -51,9 +51,8 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasTemperatureLoads.Count() == 0))
             {
-                List<Bar> barsList = ReadBars();
-                Dictionary<string, Bar> bars = barsList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                List<Bar> barsList = GetCachedOrRead<Bar>();
+                Dictionary<string, Bar> bars = barsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 

--- a/Lusas_Adapter/CRUD/Read/Loads/BarUniformlyDistributedLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/BarUniformlyDistributedLoads.cs
@@ -55,9 +55,8 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasDistributedLoads.Count() == 0))
             {
-                List<Bar> barsList = ReadBars();
-                Dictionary<string, Bar> bars = barsList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                List<Bar> barsList = GetCachedOrRead<Bar>();
+                Dictionary<string, Bar> bars = barsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 

--- a/Lusas_Adapter/CRUD/Read/Loads/BarVaryingDistributedLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/BarVaryingDistributedLoads.cs
@@ -52,9 +52,8 @@ namespace BH.Adapter.Lusas
 
             if (lusasInternalBeamDistributedLoads.Count() != 0)
             {
-                List<Bar> barsList = ReadBars();
-                Dictionary<string, Bar> bars = barsList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                List<Bar> barsList = GetCachedOrRead<Bar>();
+                Dictionary<string, Bar> bars = barsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 

--- a/Lusas_Adapter/CRUD/Read/Loads/GravityLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/GravityLoads.cs
@@ -51,15 +51,12 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasBodyForces.Count() == 0))
             {
-                List<Node> nodesList = ReadNodes();
-                List<Bar> barsList = ReadBars();
-                List<Panel> panelsList = ReadPanels();
-                Dictionary<string, Node> nodes = nodesList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
-                Dictionary<string, Bar> bars = barsList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
-                Dictionary<string, Panel> panels = panelsList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                List<Node> nodeList = GetCachedOrRead<Node>();
+                Dictionary<string, Node> nodes = nodeList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
+                List<Bar> barsList = GetCachedOrRead<Bar>();
+                Dictionary<string, Bar> bars = barsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
+                List<Panel> panelsList = GetCachedOrRead<Panel>();
+                Dictionary<string, Panel> panels = panelsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 

--- a/Lusas_Adapter/CRUD/Read/Loads/LoadCombinations.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/LoadCombinations.cs
@@ -48,9 +48,8 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasCombinations.Count() == 0))
             {
-                List<Loadcase> lusasLoadcases = ReadLoadcases();
-                Dictionary<string, Loadcase> loadcaseDictionary = lusasLoadcases.ToDictionary(
-                    x => x.Number.ToString());
+                List<Loadcase> lusasLoadcases = GetCachedOrRead<Loadcase>();
+                Dictionary<string, Loadcase> loadcaseDictionary = lusasLoadcases.ToDictionary(x => x.Number.ToString());
 
                 for (int i = 0; i < lusasCombinations.Count(); i++)
                 {

--- a/Lusas_Adapter/CRUD/Read/Loads/PointDisplacements.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/PointDisplacements.cs
@@ -51,9 +51,8 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasPrescribedDisplacements.Count() == 0))
             {
-                List<Node> nodesList = ReadNodes();
-                Dictionary<string, Node> nodes = nodesList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                List<Node> nodesList = GetCachedOrRead<Node>();
+                Dictionary<string, Node> nodes = nodesList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 

--- a/Lusas_Adapter/CRUD/Read/Loads/PointForces.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/PointForces.cs
@@ -52,9 +52,8 @@ namespace BH.Adapter.Lusas
 
             if (!(lusasConcentratedLoads.Count() == 0))
             {
-                List<Node> nodesList = ReadNodes();
-                Dictionary<string, Node> nodes = nodesList.ToDictionary(
-                    x => x.AdapterId<string>(typeof(LusasId)));
+                List<Node> nodesList = GetCachedOrRead<Node>();
+                Dictionary<string, Node> nodes = nodesList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
                 List<IFLoadcase> allLoadcases = new List<IFLoadcase>();
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Adapter/pull/337
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #356 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/Lusas_Toolkit/%23355%20Using%20Cache%20from%20BHoM_Adapter.gh?csf=1&web=1&e=HqpqZF

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Added `GetCachedOrRead()` where relevant to prevent multiple Reads within the same `Push` and increase speeds.

### Additional comments
<!-- As required -->
I was able to get some decent savings from the objects in the test script:
|  Objects | develop |  PR |
| :---        |    :---  |   :--- |
| `Bar`s and `Panels`      | 2.1 min. | 1.8 min.   |
| `Load`s | 1.9 min.  | 1.7 min. |
| `Node`s and `Bar`s | 3.4 min.  | 2.7 min. |

The way `Edge`s and `Panel`s are pushed could do with some more work and some of the tasks done by the BHoM_Adapter. I will investigate and see if I can squeeze it in to this PR.
