### PR TITLE
Fixed bug for LoadAxis on BarPointLoad and BarVaryingLoad

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
@@ -52,9 +52,8 @@ namespace BH.Adapter.Lusas
             IFAssignment lusasAssignment = m_LusasApplication.assignment();
             IFLoadcase assignedLoadcase = (IFLoadcase)d_LusasData.getLoadset(barDistributedLoad.Loadcase.AdapterId<int>(typeof(LusasId)));
 
-            Engine.Base.Compute.RecordWarning(
-                barDistributedLoad.GetType().ToString() + " uses parametric distances in the Lusas_Toolkit"
-                );
+            if(!barDistributedLoad.RelativePositions)
+                Engine.Base.Compute.RecordWarning(barDistributedLoad.GetType().ToString() + " uses parametric distances in the Lusas_Toolkit");
 
             List<double> valuesAtA = new List<double> {
                     barDistributedLoad.ForceAtStart.X, barDistributedLoad.ForceAtStart.Y,barDistributedLoad.ForceAtStart.Z,

--- a/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
@@ -144,7 +144,7 @@ namespace BH.Adapter.Lusas
                                 lusasBarDistributedLoads.Add(lusasBarDistributedLoad);
                                 lusasAssignment.setLoadset(assignedLoadcase);
                                 if(barDistributedLoad.Projected || barDistributedLoad.Axis == LoadAxis.Global)
-                                        Engine.Base.Compute.RecordWarning("Lusas does not support internal distributed                                                                                 moments in the global axis or as projected loads.");
+                                        Engine.Base.Compute.RecordWarning("Lusas does not support internal distributed moments in the global axis or as projected loads.");
                                 lusasBarDistributedLoad.assignTo(lusasLines, lusasAssignment);
                                 break;
 

--- a/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
@@ -77,7 +77,8 @@ namespace BH.Adapter.Lusas
                 axis = "projected";
                 if (barDistributedLoad.RelativePositions)
                 {
-                    Engine.Base.Compute.RecordError("Projected loads with parametric distances are not supported in Lusas.");
+                    Engine.Base.Compute.RecordError(barDistributedLoad.Name + " has not been pushed because the positions are relative and the loads " +
+                        "are projected. Lusas only supports projected BarVaryingLoad and actual distances.");
                     return null;
                 }
             }

--- a/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/BarDistributedLoad.cs
@@ -78,7 +78,7 @@ namespace BH.Adapter.Lusas
                 if (barDistributedLoad.RelativePositions)
                 {
                     Engine.Base.Compute.RecordError(barDistributedLoad.Name + " has not been pushed because the positions are relative and the loads " +
-                        "are projected. Lusas only supports projected BarVaryingLoad and actual distances.");
+                        "are projected (this combination is not supported in Lusas).");
                     return null;
                 }
             }

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
@@ -85,7 +85,7 @@ namespace BH.Adapter.Adapters.Lusas
             BarVaryingDistributedLoad barVarDistributedLoad = null;
 
 #if Debug17 || Release17 || Debug18 || Release18 || Debug19 || Release19
-            Engine.Base.Compute.RecordError("The " + barVarDistributedLoad.GetType().ToString() + " will have load axis set to Global and projected loads set" +
+            Engine.Base.Compute.RecordWarning("The " + barVarDistributedLoad.GetType().ToString() + " will have load axis set to Global and projected loads set" +
                 "to false. This bug is fixed in Lusas v19.1 and above.");
 #endif
 

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
@@ -82,8 +82,6 @@ namespace BH.Adapter.Adapters.Lusas
             bool projected = loadDirection == "Projected(beam)" ? true : false;
             LoadAxis axis = loadDirection == "Local(beam)" ? LoadAxis.Local : LoadAxis.Global;
 
-            Engine.Base.Compute.RecordWarning("All BarVaryingDistributedLoads pulled from Lusas are assumed to be in global coordinates and to not be projected.");
-
             BarVaryingDistributedLoad barVarDistributedLoad;
 
             barVarDistributedLoad = Engine.Structure.Create.BarVaryingDistributedLoad(

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
@@ -77,10 +77,12 @@ namespace BH.Adapter.Adapters.Lusas
             double endPosition = lusasBarDistributedLoad.getValue("endDistance");
 
             bool relativePositions = lusasBarDistributedLoad.getValue("Type") == "Parametric" ? true : false;
-            LoadAxis axis = LoadAxis.Global;
-            bool projected = false;
 
-            BH.Engine.Base.Compute.RecordWarning("All BarVaryingDistributedLoads pulled from Lusas are assumed to be in global coordinates and to not be projected.");
+            string loadDirection = lusasBarDistributedLoad.getValue("LoadDirection");
+            bool projected = loadDirection == "Projected(beam)" ? true : false;
+            LoadAxis axis = loadDirection == "Local(beam)" ? LoadAxis.Local : LoadAxis.Global;
+
+            Engine.Base.Compute.RecordWarning("All BarVaryingDistributedLoads pulled from Lusas are assumed to be in global coordinates and to not be projected.");
 
             BarVaryingDistributedLoad barVarDistributedLoad;
 

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
@@ -84,11 +84,6 @@ namespace BH.Adapter.Adapters.Lusas
 
             BarVaryingDistributedLoad barVarDistributedLoad = null;
 
-#if Debug17 || Release17 || Debug18 || Release18 || Debug19 || Release19
-            Engine.Base.Compute.RecordWarning("The " + barVarDistributedLoad.GetType().ToString() + " will have load axis set to Global and projected loads set" +
-                "to false. This bug is fixed in Lusas v19.1 and above.");
-#endif
-
             barVarDistributedLoad = Engine.Structure.Create.BarVaryingDistributedLoad(
                 loadcase,
                 assignedBars,
@@ -102,6 +97,11 @@ namespace BH.Adapter.Adapters.Lusas
                 axis,
                 projected,
                 GetName(lusasBarDistributedLoad));
+
+#if Debug17 || Release17 || Debug18 || Release18 || Debug19 || Release19
+            Engine.Base.Compute.RecordWarning("The " + barVarDistributedLoad.GetType().ToString() + " will have load axis set to Global and projected loads set" +
+                " to false. This bug is fixed in Lusas v19.1 and above.");
+#endif
 
             if (barVarDistributedLoad == null)
                 return null;

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDistributedLoad.cs
@@ -82,7 +82,12 @@ namespace BH.Adapter.Adapters.Lusas
             bool projected = loadDirection == "Projected(beam)" ? true : false;
             LoadAxis axis = loadDirection == "Local(beam)" ? LoadAxis.Local : LoadAxis.Global;
 
-            BarVaryingDistributedLoad barVarDistributedLoad;
+            BarVaryingDistributedLoad barVarDistributedLoad = null;
+
+#if Debug17 || Release17 || Debug18 || Release18 || Debug19 || Release19
+            Engine.Base.Compute.RecordError("The " + barVarDistributedLoad.GetType().ToString() + " will have load axis set to Global and projected loads set" +
+                "to false. This bug is fixed in Lusas v19.1 and above.");
+#endif
 
             barVarDistributedLoad = Engine.Structure.Create.BarVaryingDistributedLoad(
                 loadcase,

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarPointLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarPointLoad.cs
@@ -63,13 +63,15 @@ namespace BH.Adapter.Adapters.Lusas
 
             BarPointLoad barPointLoad;
 
+            LoadAxis loadAxis = lusasBarPointLoad.getValue("LoadDirection") == "Local(beam)" ? LoadAxis.Local : LoadAxis.Global;
+
             barPointLoad = Engine.Structure.Create.BarPointLoad(
                 loadcase,
                 forcePosition,
                 assignedBars,
                 forceVector,
                 momentVector,
-                LoadAxis.Global,
+                loadAxis,
                 GetName(lusasBarPointLoad));
 
             long adapterNameId = lusasBarPointLoad.getID();

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarPointLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarPointLoad.cs
@@ -63,7 +63,11 @@ namespace BH.Adapter.Adapters.Lusas
 
             BarPointLoad barPointLoad;
 
+#if Debug191 || Release191 || Debug200 || Release200
             LoadAxis loadAxis = lusasBarPointLoad.getValue("LoadDirection") == "Local(beam)" ? LoadAxis.Local : LoadAxis.Global;
+#else       
+            LoadAxis loadAxis = lusasBarPointLoad.getValue("LoadDirection") == 4 ? LoadAxis.Local : LoadAxis.Global; //4 for local, 3 for global (only two possible values)
+#endif
 
             barPointLoad = Engine.Structure.Create.BarPointLoad(
                 loadcase,
@@ -84,6 +88,3 @@ namespace BH.Adapter.Adapters.Lusas
 
     }
 }
-
-
-


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #367 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/Lusas_Toolkit/%23367%20LoadsPulledAsGlobal.gh?csf=1&web=1&e=IBUOdT

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed a bug where `BarPointLoad`s were being defaulted to `LoadAxis.Global` when pulled, despite appearing in Lusas correctly;
- Fixed a bug where `BarVaryingLoad`s were being to defaulted to `LoadAxis.Global` and `Projected = false` despite appearing in Lusas correctly;
- Updated the error message when a user tries to push `BarVaryingLoad` that has `Projected = true` and `RelativeDistance = false` - this combination is still unsupported;
- Updated warning for `BarVaryingLoad` to warn against non-parametric distances used when relevant (i.e. `RelativeDistance = false"
- Added warning for v19 and prior for `BarVaryingLoad` defaulting to `Global` and `false` projected
### Additional comments
<!-- As required -->