### PR TITLE
Fix bug for pulling results and update warning message

### DIFF
--- a/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
@@ -215,7 +215,7 @@ namespace BH.Adapter.Lusas
                 d_LusasData.flushScriptedResults();
             }
 
-            BH.Engine.Base.Compute.RecordWarning("Please note only axial strains will be returned when pulling BarStress results.");
+            BH.Engine.Base.Compute.RecordWarning("Please note only axial stress will be returned when pulling BarStress results.");
 
             return barStresses;
         }

--- a/Lusas_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -108,9 +108,9 @@ namespace BH.Adapter.Lusas
 
         /***************************************************/
 
-        private List<long> GetAllIds(BarResultRequest request)
+        private List<int> GetAllIds(BarResultRequest request)
         {
-            List<long> ids = new List<long>();
+            List<int> ids = new List<int>();
             long maxIndex = d_LusasData.getLargestLineID();
 
             for (int i = 1; i < maxIndex + 1; i++)
@@ -128,9 +128,9 @@ namespace BH.Adapter.Lusas
 
         /***************************************************/
 
-        private List<long> GetAllIds(MeshResultRequest request)
+        private List<int> GetAllIds(MeshResultRequest request)
         {
-            List<long> ids = new List<long>();
+            List<int> ids = new List<int>();
             long maxIndex = d_LusasData.getLargestSurfaceID();
 
             for (int i = 1; i < maxIndex + 1; i++)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #285 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/ESo_WOJCO0JPhMzd9EQr6PwBzgelLv1pb2NWXvIwQcg_KQ?e=BaB2gm

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed bug where `BarResults` and `MeshResults` were unable to pull when `CaseIds` were not provided due to a change from `int` to `long`
- Updated warning message when pulling `MeshStress` that incorrectly referred to `Axial strain`

### Additional comments
<!-- As required -->
@StephennipBH the original issue related to Lusas 19 but I suspect they fixed the problem in a minor version update.