### PR TITLE
Updated warning messages for invalid results

### DIFF
--- a/Lusas_Adapter/Private Helpers/GetFeatureResults.cs
+++ b/Lusas_Adapter/Private Helpers/GetFeatureResults.cs
@@ -100,13 +100,13 @@ namespace BH.Adapter.Lusas
                 if (!(resultsSet.isValidValue(featureResult)))
                 {
                     featureResult = 0;
-                    recordedWarning = true;
+                    invalidResult = true;
                 }
 
                 featureResults.Add(component, featureResult);
             }
 
-            if (recordedWarning)
+            if (invalidResult)
             { 
                 Engine.Base.Compute.RecordWarning($"Invalid results (i.e. where DOF is released) will be set to zero.");
             }

--- a/Lusas_Adapter/Private Helpers/GetFeatureResults.cs
+++ b/Lusas_Adapter/Private Helpers/GetFeatureResults.cs
@@ -45,7 +45,7 @@ namespace BH.Adapter.Lusas
         private Dictionary<string, double> GetFeatureResults(List<string> components, Dictionary<string, IFResultsComponentSet> resultsSets, IFUnitSet unitSet, int id, string suffix, int resultType = 6)
         {
             Dictionary<string, double> featureResults = new Dictionary<string, double>();
-            bool recordedWarning = false;
+            bool invalidResult = false;
             IFResultsComponentSet resultsSet = null;
 
             foreach (string component in components)

--- a/Lusas_Adapter/Private Helpers/GetFeatureResults.cs
+++ b/Lusas_Adapter/Private Helpers/GetFeatureResults.cs
@@ -23,6 +23,7 @@
 using System.Collections.Generic;
 using System;
 using Lusas.LPI;
+using System.ComponentModel;
 
 namespace BH.Adapter.Lusas
 {
@@ -45,6 +46,7 @@ namespace BH.Adapter.Lusas
         private Dictionary<string, double> GetFeatureResults(List<string> components, Dictionary<string, IFResultsComponentSet> resultsSets, IFUnitSet unitSet, int id, string suffix, int resultType = 6)
         {
             Dictionary<string, double> featureResults = new Dictionary<string, double>();
+            bool recordedWarning = false;
             IFResultsComponentSet resultsSet = null;
 
             foreach (string component in components)
@@ -99,10 +101,15 @@ namespace BH.Adapter.Lusas
                 if (!(resultsSet.isValidValue(featureResult)))
                 {
                     featureResult = 0;
-                    Engine.Base.Compute.RecordWarning($"{suffix}{id} {component} is an invalid result and will be set to zero");
+                    recordedWarning = true;
                 }
 
                 featureResults.Add(component, featureResult);
+            }
+
+            if (recordedWarning)
+            { 
+                Engine.Base.Compute.RecordWarning($"Invalid results (i.e. where DOF is released) will be set to zero");
             }
 
             return featureResults;

--- a/Lusas_Adapter/Private Helpers/GetFeatureResults.cs
+++ b/Lusas_Adapter/Private Helpers/GetFeatureResults.cs
@@ -23,7 +23,6 @@
 using System.Collections.Generic;
 using System;
 using Lusas.LPI;
-using System.ComponentModel;
 
 namespace BH.Adapter.Lusas
 {

--- a/Lusas_Adapter/Private Helpers/GetFeatureResults.cs
+++ b/Lusas_Adapter/Private Helpers/GetFeatureResults.cs
@@ -108,7 +108,7 @@ namespace BH.Adapter.Lusas
 
             if (recordedWarning)
             { 
-                Engine.Base.Compute.RecordWarning($"Invalid results (i.e. where DOF is released) will be set to zero");
+                Engine.Base.Compute.RecordWarning($"Invalid results (i.e. where DOF is released) will be set to zero.");
             }
 
             return featureResults;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Hard to understand warning messages that all gets stacked on one another. 
Want to make it clearer and more digestible for the user
Closes #370 

<!-- Add short description of what has been fixed -->
Simplified the warning message for invalid feature result value. 
Moved it out of the loop to only get one warning message

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/ERnJJaJQJidIvH8t4VTjf90BMUTtZEHQ290BZZ_oVBwntA?e=ZWu0hJ 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Updated the warning messages for invalid results. An invalid result in Lusas is when an unrestrained degree of freedom (DOF) result is requested. For example, requesting the `Mx` moment for a pin support - to simply this the result is set to 0 and a warning is raised. The previous warning listed the nodes and DOF but was not user friendly as large models would produce too many warnings.

### Additional comments
<!-- As required -->