### PR TITLE
Added handling of no cases provided for ResultRequest.

### DIFF
--- a/Lusas_Adapter/CRUD/Read/Results/ReadResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/ReadResults.cs
@@ -32,6 +32,7 @@ using BH.oM.Structure.Requests;
 using System.Linq;
 using BH.Engine.Adapters.Lusas;
 using BH.oM.Adapters.Lusas;
+using Lusas.LPI;
 
 namespace BH.Adapter.Lusas
 {
@@ -176,6 +177,14 @@ namespace BH.Adapter.Lusas
                         caseNums.Add(System.Convert.ToInt32(lCase.Item2.Number));
                     }
                     caseNums.Add((lComb as LoadCombination).AdapterId<int>(typeof(LusasId)));
+                }
+            }
+
+            else if (cases.Count == 0)
+            {
+                for (int i = 1; i <= d_LusasData.getLargestLoadsetID(); i++)
+                {
+                    caseNums.Add(i);
                 }
             }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
Fix bug for no results when no load cases is specified.
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #373 

<!-- Add short description of what has been fixed -->

When no `loadcases` is specified no result was returned without a description or warning for why. This PR sees to fix this bug by providing the results from all loadcases when no specific `cases` is specified. 

This is in line with descriptions in the `...ResultRequest` method in the `Structure_oM`
https://github.com/BHoM/BHoM/blob/7a13095ab3de961715b4a6c8c18b60771e624f2f/Structure_oM/Requests/BarResultRequest.cs#L43-L46

### Test files
<!-- Link to test files to validate the proposed changes -->

Grasshopper script, lusas .mdl file , and related lusas files provided below. 
Download all files to the same location and run the script and lusas as usual. 

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/Lusas_Toolkit/%23373%20Misleading%20hint%20in%20ResultRequest%20component?csf=1&web=1&e=BRp3ut


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Fixed bug whereby if users did not provide any LoadcaseIds, no results were returned. Now if no LoadcaseIds are provided, all LoadcaseIds will be used to return results (of all types)

### Additional comments
<!-- As required -->