### PR TITLE
Update Lusas gravity load conversion to push and pull.

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
@@ -24,11 +24,11 @@ using BH.oM.Adapters.Lusas;
 using BH.oM.Structure.Loads;
 using BH.Engine.Adapter;
 using Lusas.LPI;
+using BH.oM.Geometry;
 
 namespace BH.Adapter.Lusas
 {
-#if Debug18 || Release18
-    public partial class LusasV18Adapter
+#if Debug18 || Release18    public partial class LusasV18Adapter
 #elif Debug19 || Release19
     public partial class LusasV19Adapter
 #elif Debug191 || Release191
@@ -54,8 +54,13 @@ namespace BH.Adapter.Lusas
             }
             else
             {
+                double g = 9.8065;
                 lusasGravityLoad = d_LusasData.createLoadingBody(gravityLoad.Name);
-                lusasGravityLoad.setBody(gravityLoad.GravityDirection.X, gravityLoad.GravityDirection.Y, gravityLoad.GravityDirection.Z);
+                lusasGravityLoad.setBody(gravityLoad.GravityDirection.X * 9.806, gravityLoad.GravityDirection.Y * 9.806, gravityLoad.GravityDirection.Z * 9.806);
+                if (!(9.81 < lusasGravityLoad.getValue("accX") < 10.0 || 9.81 < lusasGravityLoad.getValue("accY") < 10.0 || 9.81 < lusasGravityLoad.getValue("accZ") < 10.0))
+                {       
+                    Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} is outside of the range 9.81 to 10.0");
+                }
             }
 
             IFAssignment lusasAssignment = m_LusasApplication.assignment();

--- a/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
@@ -28,7 +28,8 @@ using BH.oM.Geometry;
 
 namespace BH.Adapter.Lusas
 {
-#if Debug18 || Release18    public partial class LusasV18Adapter
+#if Debug18 || Release18
+    public partial class LusasV18Adapter
 #elif Debug19 || Release19
     public partial class LusasV19Adapter
 #elif Debug191 || Release191
@@ -54,12 +55,11 @@ namespace BH.Adapter.Lusas
             }
             else
             {
-                double g = 9.8065;
                 lusasGravityLoad = d_LusasData.createLoadingBody(gravityLoad.Name);
                 lusasGravityLoad.setBody(gravityLoad.GravityDirection.X * 9.806, gravityLoad.GravityDirection.Y * 9.806, gravityLoad.GravityDirection.Z * 9.806);
                 if (!(9.81 < lusasGravityLoad.getValue("accX") < 10.0 || 9.81 < lusasGravityLoad.getValue("accY") < 10.0 || 9.81 < lusasGravityLoad.getValue("accZ") < 10.0))
-                {       
-                    Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} is outside of the range 9.81 to 10.0");
+                {
+                    Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} is outside of the range 9.81 to 10.0.");
                 }
             }
 

--- a/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
@@ -56,7 +56,7 @@ namespace BH.Adapter.Lusas
             else
             {
                 lusasGravityLoad = d_LusasData.createLoadingBody(gravityLoad.Name);
-                lusasGravityLoad.setBody(gravityLoad.GravityDirection.X * g, gravityLoad.GravityDirection.Y * g, gravityLoad.GravityDirection.Z * g);
+                lusasGravityLoad.setBody(gravityLoad.GravityDirection.X * m_g, gravityLoad.GravityDirection.Y * m_g, gravityLoad.GravityDirection.Z * m_g);
             }
 
             IFAssignment lusasAssignment = m_LusasApplication.assignment();

--- a/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
@@ -56,13 +56,13 @@ namespace BH.Adapter.Lusas
             else
             {
                 lusasGravityLoad = d_LusasData.createLoadingBody(gravityLoad.Name);
-                lusasGravityLoad.setBody(gravityLoad.GravityDirection.X * 9.806, gravityLoad.GravityDirection.Y * 9.806, gravityLoad.GravityDirection.Z * 9.806);
+                lusasGravityLoad.setBody(gravityLoad.GravityDirection.X * 9.80665, gravityLoad.GravityDirection.Y * 9.80665, gravityLoad.GravityDirection.Z * 9.80665);
                 if (!
-                    ((9.81 < lusasGravityLoad.getValue("accX") && lusasGravityLoad.getValue("accX") < 10.0 || lusasGravityLoad.getValue("accX") == 0.0)
-                    || (9.81 < lusasGravityLoad.getValue("accY") && lusasGravityLoad.getValue("accY") < 10.0 || lusasGravityLoad.getValue("accY") == 0.0)
-                    || (9.81 < lusasGravityLoad.getValue("accZ") && lusasGravityLoad.getValue("accZ") < 10.0 || lusasGravityLoad.getValue("accZ") == 0.0)))
+                    ((9.8 < lusasGravityLoad.getValue("accX") && lusasGravityLoad.getValue("accX") < 10.0 || lusasGravityLoad.getValue("accX") == 0.0)
+                    || (9.8 < lusasGravityLoad.getValue("accY") && lusasGravityLoad.getValue("accY") < 10.0 || lusasGravityLoad.getValue("accY") == 0.0)
+                    || (9.8 < lusasGravityLoad.getValue("accZ") && lusasGravityLoad.getValue("accZ") < 10.0 || lusasGravityLoad.getValue("accZ") == 0.0)))
                 {
-                    Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} is outside of the range 9.81 to 10.0 m/s^2.");
+                    Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} is outside of the range 9.8 to 10.0 m/s^2.");
                 }
             }
 

--- a/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.Lusas
         {
             IFLoadingBody lusasGravityLoad;
             IFLoadcase assignedLoadcase = (IFLoadcase)d_LusasData.getLoadset(gravityLoad.Loadcase.AdapterId<int>(typeof(LusasId)));
-
+           
             if (d_LusasData.existsAttribute("Loading", gravityLoad.Name))
             {
                 lusasGravityLoad = (IFLoadingBody)d_LusasData.getAttributes("Loading", gravityLoad.Name);
@@ -56,14 +56,7 @@ namespace BH.Adapter.Lusas
             else
             {
                 lusasGravityLoad = d_LusasData.createLoadingBody(gravityLoad.Name);
-                lusasGravityLoad.setBody(gravityLoad.GravityDirection.X * 9.80665, gravityLoad.GravityDirection.Y * 9.80665, gravityLoad.GravityDirection.Z * 9.80665);
-                if (!
-                    ((9.8 < lusasGravityLoad.getValue("accX") && lusasGravityLoad.getValue("accX") < 10.0 || lusasGravityLoad.getValue("accX") == 0.0)
-                    || (9.8 < lusasGravityLoad.getValue("accY") && lusasGravityLoad.getValue("accY") < 10.0 || lusasGravityLoad.getValue("accY") == 0.0)
-                    || (9.8 < lusasGravityLoad.getValue("accZ") && lusasGravityLoad.getValue("accZ") < 10.0 || lusasGravityLoad.getValue("accZ") == 0.0)))
-                {
-                    Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} is outside of the range 9.8 to 10.0 m/s^2.");
-                }
+                lusasGravityLoad.setBody(gravityLoad.GravityDirection.X * g, gravityLoad.GravityDirection.Y * g, gravityLoad.GravityDirection.Z * g);
             }
 
             IFAssignment lusasAssignment = m_LusasApplication.assignment();

--- a/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/GravityLoad.cs
@@ -57,9 +57,12 @@ namespace BH.Adapter.Lusas
             {
                 lusasGravityLoad = d_LusasData.createLoadingBody(gravityLoad.Name);
                 lusasGravityLoad.setBody(gravityLoad.GravityDirection.X * 9.806, gravityLoad.GravityDirection.Y * 9.806, gravityLoad.GravityDirection.Z * 9.806);
-                if (!(9.81 < lusasGravityLoad.getValue("accX") < 10.0 || 9.81 < lusasGravityLoad.getValue("accY") < 10.0 || 9.81 < lusasGravityLoad.getValue("accZ") < 10.0))
+                if (!
+                    ((9.81 < lusasGravityLoad.getValue("accX") && lusasGravityLoad.getValue("accX") < 10.0 || lusasGravityLoad.getValue("accX") == 0.0)
+                    || (9.81 < lusasGravityLoad.getValue("accY") && lusasGravityLoad.getValue("accY") < 10.0 || lusasGravityLoad.getValue("accY") == 0.0)
+                    || (9.81 < lusasGravityLoad.getValue("accZ") && lusasGravityLoad.getValue("accZ") < 10.0 || lusasGravityLoad.getValue("accZ") == 0.0)))
                 {
-                    Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} is outside of the range 9.81 to 10.0.");
+                    Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} is outside of the range 9.81 to 10.0 m/s^2.");
                 }
             }
 

--- a/Lusas_Adapter/CRUD/Read/Loads/GravityLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/GravityLoads.cs
@@ -72,9 +72,9 @@ namespace BH.Adapter.Lusas
                     foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
                     {
                         List<string> analysisName = new List<string> { lusasBodyForce.getAttributeType() };
-
+                        
                         GravityLoad gravityLoad = Adapters.Lusas.Convert.ToGravityLoad(
-                            lusasBodyForce, groupedAssignment, nodes, bars, panels);
+                            lusasBodyForce, groupedAssignment, nodes, bars, panels, g);
                         gravityLoad.Tags = new HashSet<string>(analysisName);
                         gravityLoads.Add(gravityLoad);
                     }

--- a/Lusas_Adapter/CRUD/Read/Loads/GravityLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/GravityLoads.cs
@@ -74,7 +74,7 @@ namespace BH.Adapter.Lusas
                         List<string> analysisName = new List<string> { lusasBodyForce.getAttributeType() };
                         
                         GravityLoad gravityLoad = Adapters.Lusas.Convert.ToGravityLoad(
-                            lusasBodyForce, groupedAssignment, nodes, bars, panels, g);
+                            lusasBodyForce, groupedAssignment, nodes, bars, panels, m_g);
                         gravityLoad.Tags = new HashSet<string>(analysisName);
                         gravityLoads.Add(gravityLoad);
                     }

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
@@ -42,24 +42,18 @@ namespace BH.Adapter.Adapters.Lusas
             IEnumerable<IFAssignment> lusasAssignments,
             Dictionary<string, Node> nodes,
             Dictionary<string, Bar> bars,
-            Dictionary<string, Panel> panels)
+            Dictionary<string, Panel> panels,
+            double g)
+
         {
             IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
             Loadcase loadcase = ToLoadcase(assignedLoadcase);
             Vector gravityVector = new Vector
             {
-                X = lusasGravityLoad.getValue("accX") / 9.80665,
-                Y = lusasGravityLoad.getValue("accY") / 9.80665,
-                Z = lusasGravityLoad.getValue("accZ") / 9.80665
+                X = lusasGravityLoad.getValue("accX") / g,
+                Y = lusasGravityLoad.getValue("accY") / g,
+                Z = lusasGravityLoad.getValue("accZ") / g
             };
-
-            if (!
-                    ((9.8 < lusasGravityLoad.getValue("accX") && lusasGravityLoad.getValue("accX") < 10.0 || lusasGravityLoad.getValue("accX") == 0.0)
-                    || (9.8 < lusasGravityLoad.getValue("accY") && lusasGravityLoad.getValue("accY") < 10.0 || lusasGravityLoad.getValue("accY") == 0.0)
-                    || (9.8 < lusasGravityLoad.getValue("accZ") && lusasGravityLoad.getValue("accZ") < 10.0 || lusasGravityLoad.getValue("accZ") == 0.0)))
-            {
-                Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} outside of the range 9.8 to 10.0.");
-            }
 
             IEnumerable<BHoMObject> assignedObjects = GetGeometryAssignments(
                 lusasAssignments, nodes, bars, panels);

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
@@ -48,17 +48,17 @@ namespace BH.Adapter.Adapters.Lusas
             Loadcase loadcase = ToLoadcase(assignedLoadcase);
             Vector gravityVector = new Vector
             {
-                X = lusasGravityLoad.getValue("accX") / 9.806,
-                Y = lusasGravityLoad.getValue("accY") / 9.806,
-                Z = lusasGravityLoad.getValue("accZ") / 9.806
+                X = lusasGravityLoad.getValue("accX") / 9.80665,
+                Y = lusasGravityLoad.getValue("accY") / 9.80665,
+                Z = lusasGravityLoad.getValue("accZ") / 9.80665
             };
 
             if (!
-                    ((9.81 < lusasGravityLoad.getValue("accX") && lusasGravityLoad.getValue("accX") < 10.0 || lusasGravityLoad.getValue("accX") == 0.0)
-                    || (9.81 < lusasGravityLoad.getValue("accY") && lusasGravityLoad.getValue("accY") < 10.0 || lusasGravityLoad.getValue("accY") == 0.0)
-                    || (9.81 < lusasGravityLoad.getValue("accZ") && lusasGravityLoad.getValue("accZ") < 10.0 || lusasGravityLoad.getValue("accZ") == 0.0)))
+                    ((9.8 < lusasGravityLoad.getValue("accX") && lusasGravityLoad.getValue("accX") < 10.0 || lusasGravityLoad.getValue("accX") == 0.0)
+                    || (9.8 < lusasGravityLoad.getValue("accY") && lusasGravityLoad.getValue("accY") < 10.0 || lusasGravityLoad.getValue("accY") == 0.0)
+                    || (9.8 < lusasGravityLoad.getValue("accZ") && lusasGravityLoad.getValue("accZ") < 10.0 || lusasGravityLoad.getValue("accZ") == 0.0)))
             {
-                Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} outside of the range 9.81 to 10.0.");
+                Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} outside of the range 9.8 to 10.0.");
             }
 
             IEnumerable<BHoMObject> assignedObjects = GetGeometryAssignments(

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
@@ -53,9 +53,12 @@ namespace BH.Adapter.Adapters.Lusas
                 Z = lusasGravityLoad.getValue("accZ") / 9.806
             };
 
-            if (!(9.81 < lusasGravityLoad.getValue("accX") < 10.0 || 9.81 < lusasGravityLoad.getValue("accY") < 10.0 || 9.81 < lusasGravityLoad.getValue("accZ") < 10.0))
+            if (!
+                    ((9.81 < lusasGravityLoad.getValue("accX") && lusasGravityLoad.getValue("accX") < 10.0 || lusasGravityLoad.getValue("accX") == 0.0)
+                    || (9.81 < lusasGravityLoad.getValue("accY") && lusasGravityLoad.getValue("accY") < 10.0 || lusasGravityLoad.getValue("accY") == 0.0)
+                    || (9.81 < lusasGravityLoad.getValue("accZ") && lusasGravityLoad.getValue("accZ") < 10.0 || lusasGravityLoad.getValue("accZ") == 0.0)))
             {
-                Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} is outside of the range 9.81 to 10.0.");
+                Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} outside of the range 9.81 to 10.0.");
             }
 
             IEnumerable<BHoMObject> assignedObjects = GetGeometryAssignments(

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToGravityLoad.cs
@@ -48,10 +48,15 @@ namespace BH.Adapter.Adapters.Lusas
             Loadcase loadcase = ToLoadcase(assignedLoadcase);
             Vector gravityVector = new Vector
             {
-                X = lusasGravityLoad.getValue("accX"),
-                Y = lusasGravityLoad.getValue("accY"),
-                Z = lusasGravityLoad.getValue("accZ")
+                X = lusasGravityLoad.getValue("accX") / 9.806,
+                Y = lusasGravityLoad.getValue("accY") / 9.806,
+                Z = lusasGravityLoad.getValue("accZ") / 9.806
             };
+
+            if (!(9.81 < lusasGravityLoad.getValue("accX") < 10.0 || 9.81 < lusasGravityLoad.getValue("accY") < 10.0 || 9.81 < lusasGravityLoad.getValue("accZ") < 10.0))
+            {
+                Engine.Base.Compute.RecordWarning($"The the gravitational acceleration of {lusasGravityLoad.getName()} is outside of the range 9.81 to 10.0.");
+            }
 
             IEnumerable<BHoMObject> assignedObjects = GetGeometryAssignments(
                 lusasAssignments, nodes, bars, panels);

--- a/Lusas_Adapter/LusasAdapter.cs
+++ b/Lusas_Adapter/LusasAdapter.cs
@@ -169,6 +169,8 @@ namespace BH.Adapter.Lusas
                         m_mergeTolerance = lusasSettings.MergeTolerance;
                         d_LusasData.getOptions().setDouble("TOLMRG", m_mergeTolerance);
                     }
+
+                    if (lusasSettings != null) { g = lusasSettings.GravitationalForceEquivalent; }
                 }
             }
         }
@@ -190,6 +192,7 @@ namespace BH.Adapter.Lusas
 
         private string m_directory;
         public double m_mergeTolerance = double.NaN;
+        public double g = 9.807;
         public LusasWinApp m_LusasApplication;
         public IFDatabase d_LusasData;
         private Dictionary<Type, Dictionary<int, HashSet<string>>> m_tags = new Dictionary<Type, Dictionary<int, HashSet<string>>>();

--- a/Lusas_Adapter/LusasAdapter.cs
+++ b/Lusas_Adapter/LusasAdapter.cs
@@ -192,7 +192,7 @@ namespace BH.Adapter.Lusas
 
         private string m_directory;
         public double m_mergeTolerance = double.NaN;
-        public double g = 9.807;
+        public double m_g = 9.807;
         public LusasWinApp m_LusasApplication;
         public IFDatabase d_LusasData;
         private Dictionary<Type, Dictionary<int, HashSet<string>>> m_tags = new Dictionary<Type, Dictionary<int, HashSet<string>>>();

--- a/Lusas_Adapter/LusasAdapter.cs
+++ b/Lusas_Adapter/LusasAdapter.cs
@@ -170,7 +170,7 @@ namespace BH.Adapter.Lusas
                         d_LusasData.getOptions().setDouble("TOLMRG", m_mergeTolerance);
                     }
 
-                    if (lusasSettings != null) { g = lusasSettings.GravitationalForceEquivalent; }
+                    if (lusasSettings != null) { m_g = lusasSettings.StandardGravity; }
                 }
             }
         }
@@ -192,7 +192,7 @@ namespace BH.Adapter.Lusas
 
         private string m_directory;
         public double m_mergeTolerance = double.NaN;
-        public double m_g = 9.807;
+        public double m_g = 9.80665;
         public LusasWinApp m_LusasApplication;
         public IFDatabase d_LusasData;
         private Dictionary<Type, Dictionary<int, HashSet<string>>> m_tags = new Dictionary<Type, Dictionary<int, HashSet<string>>>();

--- a/Lusas_Engine/Create/LusasSettings.cs
+++ b/Lusas_Engine/Create/LusasSettings.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Adapters.Lusas
         [Description("Lusas adapter settings.")]
         [Input("mergeTolerance", "Sets the merging tolerance used in Lusas.")]
         [Input("librarySettings", "Sets the library settings.")]
-        [Input("m_g", "Sets the gravitational force equivalent. Used when converting gravity loads between BHoM and Lusas.")]
+        [Input("g", "Sets the standard gravity i.e. the acceleration due to gravity. This is used when GravityLoads are pushed/pulled from Lusas as the BHoM uses a factor of g, whereas Lusas uses a specific acceleration.")]
         [Output("Lusas specific adapter settings to be used by the adapter.")]
         public static LusasSettings LusasSettings(double mergeTolerance, LibrarySettings librarySettings = null, double m_g = 9.807)
         {

--- a/Lusas_Engine/Create/LusasSettings.cs
+++ b/Lusas_Engine/Create/LusasSettings.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Adapters.Lusas
         [Description("Lusas adapter settings.")]
         [Input("mergeTolerance", "Sets the merging tolerance used in Lusas.")]
         [Input("librarySettings", "Sets the library settings.")]
-        [Input("m_g", "Sets the gravitational force equivalent. Used when converting gravitaional loads between BHoM and Lusas.")]
+        [Input("m_g", "Sets the gravitational force equivalent. Used when converting gravity loads between BHoM and Lusas.")]
         [Output("Lusas specific adapter settings to be used by the adapter.")]
         public static LusasSettings LusasSettings(double mergeTolerance, LibrarySettings librarySettings = null, double m_g = 9.807)
         {

--- a/Lusas_Engine/Create/LusasSettings.cs
+++ b/Lusas_Engine/Create/LusasSettings.cs
@@ -36,8 +36,9 @@ namespace BH.Engine.Adapters.Lusas
         [Description("Lusas adapter settings.")]
         [Input("mergeTolerance", "Sets the merging tolerance used in Lusas.")]
         [Input("librarySettings", "Sets the library settings.")]
+        [Input("m_g", "Sets the gravitational force equivalent. Used when converting gravitaional loads between BHoM and Lusas.")]
         [Output("Lusas specific adapter settings to be used by the adapter.")]
-        public static LusasSettings LusasSettings(double mergeTolerance, LibrarySettings librarySettings = null)
+        public static LusasSettings LusasSettings(double mergeTolerance, LibrarySettings librarySettings = null, double m_g = 9.807)
         {
             LusasSettings lusasSettings = new LusasSettings();
 
@@ -45,6 +46,8 @@ namespace BH.Engine.Adapters.Lusas
 
             if (librarySettings != null)
                 lusasSettings.LibrarySettings = librarySettings;
+
+            lusasSettings.GravitationalForceEquivalent = m_g;
 
             return lusasSettings;
         }

--- a/Lusas_Engine/Create/LusasSettings.cs
+++ b/Lusas_Engine/Create/LusasSettings.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Adapters.Lusas
         [Input("librarySettings", "Sets the library settings.")]
         [Input("g", "Sets the standard gravity i.e. the acceleration due to gravity. This is used when GravityLoads are pushed/pulled from Lusas as the BHoM uses a factor of g, whereas Lusas uses a specific acceleration.")]
         [Output("Lusas specific adapter settings to be used by the adapter.")]
-        public static LusasSettings LusasSettings(double mergeTolerance, LibrarySettings librarySettings = null, double g = 9.807)
+        public static LusasSettings LusasSettings(double mergeTolerance, LibrarySettings librarySettings = null, double g = 9.80665)
         {
             LusasSettings lusasSettings = new LusasSettings();
 
@@ -47,7 +47,7 @@ namespace BH.Engine.Adapters.Lusas
             if (librarySettings != null)
                 lusasSettings.LibrarySettings = librarySettings;
 
-            lusasSettings.GravitationalForceEquivalent = g;
+            lusasSettings.StandardGravity = g;
 
             return lusasSettings;
         }

--- a/Lusas_Engine/Create/LusasSettings.cs
+++ b/Lusas_Engine/Create/LusasSettings.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Adapters.Lusas
             if (librarySettings != null)
                 lusasSettings.LibrarySettings = librarySettings;
 
-            lusasSettings.GravitationalForceEquivalent = m_g;
+            lusasSettings.GravitationalForceEquivalent = g;
 
             return lusasSettings;
         }

--- a/Lusas_Engine/Create/LusasSettings.cs
+++ b/Lusas_Engine/Create/LusasSettings.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Adapters.Lusas
         [Input("librarySettings", "Sets the library settings.")]
         [Input("g", "Sets the standard gravity i.e. the acceleration due to gravity. This is used when GravityLoads are pushed/pulled from Lusas as the BHoM uses a factor of g, whereas Lusas uses a specific acceleration.")]
         [Output("Lusas specific adapter settings to be used by the adapter.")]
-        public static LusasSettings LusasSettings(double mergeTolerance, LibrarySettings librarySettings = null, double m_g = 9.807)
+        public static LusasSettings LusasSettings(double mergeTolerance, LibrarySettings librarySettings = null, double g = 9.807)
         {
             LusasSettings lusasSettings = new LusasSettings();
 

--- a/Lusas_oM/Lusas_oM.csproj
+++ b/Lusas_oM/Lusas_oM.csproj
@@ -144,6 +144,11 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+        <Reference Include="Quantities_oM">
+      <HintPath>$(ProgramData)\BHoM\Assemblies\Quantities_oM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/Lusas_oM/Settings/LusasSettings.cs
+++ b/Lusas_oM/Settings/LusasSettings.cs
@@ -38,7 +38,7 @@ namespace BH.oM.Adapters.Lusas
         [Description("Sets the library settings.")]
         public virtual LibrarySettings LibrarySettings { get; set; } = new LibrarySettings();
 
-        [Acceleration]
+        //[Acceleration]
         [Description("Sets the standard gravity i.e. the acceleration due to gravity. This is used when GravityLoads are pushed/pulled from Lusas as the BHoM uses a factor of g, whereas Lusas uses a specific acceleration.")]
         public virtual double StandardGravity { get; set; } = 9.80665;
 

--- a/Lusas_oM/Settings/LusasSettings.cs
+++ b/Lusas_oM/Settings/LusasSettings.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base;
 using System.ComponentModel;
 using BH.oM.Adapter;
+using BH.oM.Quantities.Attributes;
 
 namespace BH.oM.Adapters.Lusas
 {
@@ -31,14 +32,14 @@ namespace BH.oM.Adapters.Lusas
         /***************************************************/
         /****            Public Properties              ****/
         /***************************************************/
- 
+
         [Description("Sets the merging tolerance used in Lusas.")]
         public virtual double MergeTolerance { get; set; } = double.NaN;
 
         [Description("Sets the library settings.")]
         public virtual LibrarySettings LibrarySettings { get; set; } = new LibrarySettings();
 
-        //[Acceleration]
+        [Acceleration]
         [Description("Sets the standard gravity i.e. the acceleration due to gravity. This is used when GravityLoads are pushed/pulled from Lusas as the BHoM uses a factor of g, whereas Lusas uses a specific acceleration.")]
         public virtual double StandardGravity { get; set; } = 9.80665;
 

--- a/Lusas_oM/Settings/LusasSettings.cs
+++ b/Lusas_oM/Settings/LusasSettings.cs
@@ -38,8 +38,9 @@ namespace BH.oM.Adapters.Lusas
         [Description("Sets the library settings.")]
         public virtual LibrarySettings LibrarySettings { get; set; } = new LibrarySettings();
 
-        [Description("Sets the gravitational force equivalent. Used when converting gravity loads between BHoM and Lusas.")]
-        public virtual double GravitationalForceEquivalent { get; set; } = 9.807;
+        [Acceleration]
+        [Description("Sets the standard gravity i.e. the acceleration due to gravity. This is used when GravityLoads are pushed/pulled from Lusas as the BHoM uses a factor of g, whereas Lusas uses a specific acceleration.")]
+        public virtual double StandardGravity { get; set; } = 9.80665;
 
         /***************************************************/
     }

--- a/Lusas_oM/Settings/LusasSettings.cs
+++ b/Lusas_oM/Settings/LusasSettings.cs
@@ -38,6 +38,9 @@ namespace BH.oM.Adapters.Lusas
         [Description("Sets the library settings.")]
         public virtual LibrarySettings LibrarySettings { get; set; } = new LibrarySettings();
 
+        [Description("Sets the gravitational force equivalent. Used when converting gravity loads between BHoM and Lusas.")]
+        public virtual double GravitationalForceEquivalent { get; set; } = 9.807;
+
         /***************************************************/
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #333 

Addresses the issue of the gravity load not matching the description by converting the load by multiplying with 9.80665, `g`.
The mirrored conversion is made when pulling the load back, dividing by 9.80665.
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/Lusas_Toolkit/%23333-GravityLoad%20not%20matching%20oM%20description?csf=1&web=1&e=xEff34

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed a bug whereby the description for the `GravityLoad` did not match the output in Lusas.
- Added variable to `LusasSettings`.
- Sets default value of `m_g` to in 9.80665 in `LusasAdapter`. 
- Overwrites the value from `LusasSettings` if `LusasSettings` is provided.
-  Converting `gravityLoad` with `g` in push and pull.  


### Additional comments
<!-- As required -->