### PR TITLE
Fix bug for pushing loadcase (number) that exists in Lusas.

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -54,18 +54,20 @@ namespace BH.Adapter.Lusas
                 if (lusasLoadcase.getID() != loadcase.Number) 
                 {
                     Compute.RecordWarning(
-                        $"The loadcase {loadcase.Name} already exists but the number {lusasLoadcase.getID()} does not match with the loadcase being pushed: {loadcase.Name}, {loadcase.Number}. \n" +
-                        $"The loadcase {lusasLoadcase.getName()} has been used."); 
+                    $"The loadcase {loadcase.Name} already exists but the number {lusasLoadcase.getID()} does not match with the loadcase being pushed: {loadcase.Name}, {loadcase.Number}. \n" +
+                    $"The loadcase {lusasLoadcase.getName()} has been used.");
+                    loadcase.Number = (int)lusasLoadcase.getID();
                 };
             }
             if (d_LusasData.existsLoadset(loadcase.Number))
             {
                 lusasLoadcase = (IFLoadcase)d_LusasData.getLoadset(loadcase.Number);
                 if (lusasLoadcase.getName() != loadcase.Name)
-                { 
+                {
                     Compute.RecordWarning(
-                        $"A loadcase with the number {loadcase.Number} already exists but the name {lusasLoadcase.getName()} does not match with the loadcase being pushed: {loadcase.Name}, {loadcase.Number}. /n" +
-                        $"Make sure you are using a unique name and number. {lusasLoadcase.getName()} has been used");         
+                    $"The loadcase {loadcase.Number} already exists but the number {lusasLoadcase.getID()} does not match with the loadcase being pushed: {loadcase.Name}, {loadcase.Number}. \n" +
+                    $"The loadcase {lusasLoadcase.getName()} has been used.");
+                    loadcase.Name = lusasLoadcase.getName();
                 };
             }
             else

--- a/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -48,17 +48,6 @@ namespace BH.Adapter.Lusas
         {
             IFLoadcase lusasLoadcase;
 
-            if (d_LusasData.existsLoadset(loadcase.Name))
-            {
-                lusasLoadcase = (IFLoadcase)d_LusasData.getLoadset(loadcase.Name);
-                if (lusasLoadcase.getID() != loadcase.Number) 
-                {
-                    Compute.RecordWarning(
-                    $"The loadcase {loadcase.Name} already exists but the number {lusasLoadcase.getID()} does not match with the loadcase being pushed: {loadcase.Name}, {loadcase.Number}. \n" +
-                    $"The loadcase {lusasLoadcase.getName()} has been used.");
-                    loadcase.Number = (int)lusasLoadcase.getID();
-                };
-            }
             if (d_LusasData.existsLoadset(loadcase.Number))
             {
                 lusasLoadcase = (IFLoadcase)d_LusasData.getLoadset(loadcase.Number);

--- a/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -54,8 +54,8 @@ namespace BH.Adapter.Lusas
                 if (lusasLoadcase.getID() != loadcase.Number) 
                 {
                     Compute.RecordWarning(
-                        $"A loadcase with the name {loadcase.Name} already exists but the number {lusasLoadcase.getID()} does not match with the loadcase being pushed: {loadcase.Name}, {loadcase.Number}. /n" +
-                        $"Make sure you are using a unique name and number. {lusasLoadcase.getName()} has been used"); 
+                        $"The loadcase {loadcase.Name} already exists but the number {lusasLoadcase.getID()} does not match with the loadcase being pushed: {loadcase.Name}, {loadcase.Number}. \n" +
+                        $"The loadcase {lusasLoadcase.getName()} has been used."); 
                 };
             }
             if (d_LusasData.existsLoadset(loadcase.Number))

--- a/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -52,6 +52,10 @@ namespace BH.Adapter.Lusas
             {
                 lusasLoadcase = (IFLoadcase)d_LusasData.getLoadset(loadcase.Name);
             }
+            if (d_LusasData.existsLoadset(loadcase.Number))
+            {
+                lusasLoadcase = (IFLoadcase)d_LusasData.getLoadset(loadcase.Number);
+            }
             else
             {
                 if (loadcase.Number == 0)

--- a/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -51,10 +51,18 @@ namespace BH.Adapter.Lusas
             if (d_LusasData.existsLoadset(loadcase.Name))
             {
                 lusasLoadcase = (IFLoadcase)d_LusasData.getLoadset(loadcase.Name);
+                if (lusasLoadcase.getID() != loadcase.Number) 
+                {
+                    Compute.RecordError($"A loadcase with the name {loadcase.Name} already exists but the number does not match with the loadcase being pushed./nMake sure you are using a unique name and number."); 
+                };
             }
             if (d_LusasData.existsLoadset(loadcase.Number))
             {
                 lusasLoadcase = (IFLoadcase)d_LusasData.getLoadset(loadcase.Number);
+                if (lusasLoadcase.getName() != loadcase.Name)
+                { 
+                    Compute.RecordError($"A loadcase with the number {loadcase.Number} already exists but the name does not match with the loadcase being pushed./nMake sure you are using a unique name and number.");         
+                };
             }
             else
             {

--- a/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -53,7 +53,9 @@ namespace BH.Adapter.Lusas
                 lusasLoadcase = (IFLoadcase)d_LusasData.getLoadset(loadcase.Name);
                 if (lusasLoadcase.getID() != loadcase.Number) 
                 {
-                    Compute.RecordError($"A loadcase with the name {loadcase.Name} already exists but the number does not match with the loadcase being pushed./nMake sure you are using a unique name and number."); 
+                    Compute.RecordWarning(
+                        $"A loadcase with the name {loadcase.Name} already exists but the number {lusasLoadcase.getID()} does not match with the loadcase being pushed: {loadcase.Name}, {loadcase.Number}. /n" +
+                        $"Make sure you are using a unique name and number. {lusasLoadcase.getName()} has been used"); 
                 };
             }
             if (d_LusasData.existsLoadset(loadcase.Number))
@@ -61,7 +63,9 @@ namespace BH.Adapter.Lusas
                 lusasLoadcase = (IFLoadcase)d_LusasData.getLoadset(loadcase.Number);
                 if (lusasLoadcase.getName() != loadcase.Name)
                 { 
-                    Compute.RecordError($"A loadcase with the number {loadcase.Number} already exists but the name does not match with the loadcase being pushed./nMake sure you are using a unique name and number.");         
+                    Compute.RecordWarning(
+                        $"A loadcase with the number {loadcase.Number} already exists but the name {lusasLoadcase.getName()} does not match with the loadcase being pushed: {loadcase.Name}, {loadcase.Number}. /n" +
+                        $"Make sure you are using a unique name and number. {lusasLoadcase.getName()} has been used");         
                 };
             }
             else


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #372 

<!-- Add short description of what has been fixed -->
- Fixed a bug when pushing `Loadcase` with a number that already exists in Lusas - the properties would all be deassigned.

### Test files
<!-- Link to test files to validate the proposed changes -->

[TestScript](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FLusas%5FToolkit%2F%23383%2DFixBugForPushingLoadcasenumberThatExistsInLusas%2F%23372%20Unassigns%20properties%20when%20pushing%20loads%20%281%29%2Egh&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FLusas%5FToolkit%2F%23383%2DFixBugForPushingLoadcasenumberThatExistsInLusas)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added check if `loadcase.Number` exists in Lusas. If so uses that `Loadcase`.

### Additional comments
<!-- As required -->

Testscript show some Loadcases named in a not recommended way to test how that would get handled.