### PR TITLE
Change toe radius default value to zero

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
+++ b/Lusas_Adapter/CRUD/Create/Properties/GeometricLine.cs
@@ -257,6 +257,8 @@ namespace BH.Adapter.Lusas
             int lusasType = 5;
             CreateLibrarySection(name, dimensionArray, lusasType);
 
+            Engine.Base.Compute.RecordWarning("Toe radius not supported in Lusas. 0 is used for toe radius");
+
             return true;
         }
 

--- a/Lusas_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Properties/ToProfile.cs
@@ -82,7 +82,7 @@ namespace BH.Adapter.Adapters.Lusas
                             lusasAttribute.getValue("tw",i),
                             lusasAttribute.getValue("tf",i),
                             lusasAttribute.getValue("r",i),
-                            lusasAttribute.getValue("r",i)
+                            0
                         );
                         break;
                     }

--- a/Lusas_Engine/Query/InvalidSectionProfile.cs
+++ b/Lusas_Engine/Query/InvalidSectionProfile.cs
@@ -43,9 +43,10 @@ namespace BH.Engine.Adapters.Lusas
                 sectionProfile is GeneralisedTSectionProfile ||
                 sectionProfile is FreeFormProfile ||
                 sectionProfile is KiteProfile)
+            {
                 isInvalid = true;
                 Base.Compute.RecordWarning("Unsupported SectionProfile (GeneralisedFabricatedBoxProfile, GeneralisedTSectionProfile, FreeformProfile or KiteProfile) assigned to Bar SectionProperty.");
-
+            }
             return isInvalid;
         }
     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #386 

<!-- Add short description of what has been fixed -->

Lusas does not support `toeRadius`. When pulling back I-sections the `rootRadius` from Lusas was used to set the `toeRadius`. This resulted in thin profiles becoming inconceivable and not being pulled. 

Change is made so that the toe radius is set to `0` instead. This is in line with how Lusas handles the section. 

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/Lusas_Toolkit/%23386%20sections%20not%20handled%20correctly%20in%20push%20and%20pull.gh?csf=1&web=1&e=A4fzFf 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed a bug whereby the toe radius was being pulled back equivalent to the root radius, which was resulting in unfeasible profiles for thin flanged sections;
- Added a warning when pushing `ISection` that has a toe radius;

### Additional comments
<!-- As required -->

Question is if any of the other sections should be changed now as well. For example the T section is bound to have the same issue.

Change could also be made so that the `rootRadius` is used for the `toeRadius` when that results in a valid section and the `toeRadius` is set to `0` when it needs to. I would rather opt for the way it is done now with always setting it to `0` as that is in line with Lusas.
