### PR TITLE
Add support for Panel with Openings

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -403,13 +403,13 @@ namespace BH.Adapter.Lusas
                                         }                               
                                 }
                                 else
-                                    Engine.Base.Compute.RecordWarning("The geometry defining one of the Openings of the Panel is not Planar, and therefore the Opening will not be created.");
+                                    Engine.Base.Compute.RecordError("The geometry defining one of the Openings of the Panel is not Planar, and therefore the Opening will not be created.");
                             }
                             else
-                                Engine.Base.Compute.RecordWarning("One or more of the Internal Edges of the Panel are invalid, and therefore the Opening will not be created.");
+                                Engine.Base.Compute.RecordError("One or more of the Internal Edges of the Panel are invalid, and therefore the Opening will not be created.");
                         }
                         else
-                            Engine.Base.Compute.RecordWarning("One of more of the Internal Edges of the Panel or Curves defining the Opening are null.");
+                            Engine.Base.Compute.RecordError("One of more of the Internal Edges of the Panel or Curves defining the Opening are null.");
                 }
 
 

--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -278,7 +278,7 @@ namespace BH.Adapter.Lusas
                                 {                                    
                                     if (panel.ExternalEdges.All(x => !Engine.Adapters.Lusas.Query.InvalidEdge(x)))
                                     {
-                                        if (Engine.Spatial.Query.IsPlanar(panel, false, Tolerance.MacroDistance))
+                                        if (Engine.Spatial.Query.IsPlanar(panel, true, Tolerance.MacroDistance))
                                         {
                                             for (int i = 0; i < panel.ExternalEdges.Count; i++)
                                             {

--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -393,22 +393,14 @@ namespace BH.Adapter.Lusas
                             {
                                 if (Engine.Spatial.Query.IsPlanar(opening, false, Tolerance.MacroDistance)) //Check if this works.
                                 {
-                                    //if (Engine.Geometry.Query.IsCoplanar(opening.FitPlane(), panel.FitPlane(), Tolerance.MacroDistance)) //Fix this check. Move this check.
-                                    //{
                                         for (int i = 0; i < opening.Edges.Count; i++)
                                         {
-                                            //Need to have a think which errors should give a warning and which should give an error... 
-                                            //Not fun to have it structured like this. Surely there is a better way...
-
                                             if (!CheckPropertyError(opening, p => opening.Edges[i]) && Engine.Adapters.Lusas.Query.InvalidEdge(opening.Edges[i]))
                                                 break;
 
                                             if (i == opening.Edges.Count - 1)
                                                 validOpenings.Add(opening);
-                                        }
-                                    //}
-                                    //else
-                                        //Engine.Base.Compute.RecordError("The geometry defining the Panel is not Coplanar with at least one of the Openings, and therefore the Panel will not be created.");
+                                        }                               
                                 }
                                 else
                                     Engine.Base.Compute.RecordWarning("The geometry defining one of the Openings of the Panel is not Planar, and therefore the Opening will not be created.");

--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -40,8 +40,6 @@ using System.Linq;
 using BH.Engine.Base.Objects;
 using BH.Engine.Base;
 using BH.oM.Adapters.Lusas.Fragments;
-using System.Windows.Forms.VisualStyles;
-using BH.Engine.Spatial;
 
 namespace BH.Adapter.Lusas
 {
@@ -413,13 +411,13 @@ namespace BH.Adapter.Lusas
                                         //Engine.Base.Compute.RecordError("The geometry defining the Panel is not Coplanar with at least one of the Openings, and therefore the Panel will not be created.");
                                 }
                                 else
-                                    Engine.Base.Compute.RecordError("The geometry defining one of the Openings of the Panel is not Planar, and therefore the Panel will not be created.");
+                                    Engine.Base.Compute.RecordWarning("The geometry defining one of the Openings of the Panel is not Planar, and therefore the Opening will not be created.");
                             }
                             else
-                                Engine.Base.Compute.RecordError("One or more of the Internal Edges of the Panel are invalid.");
+                                Engine.Base.Compute.RecordWarning("One or more of the Internal Edges of the Panel are invalid, and therefore the Opening will not be created.");
                         }
                         else
-                            Engine.Base.Compute.RecordError("One of more of the Internal Edges of the Panel or Curves defining the Opening are null.");
+                            Engine.Base.Compute.RecordWarning("One of more of the Internal Edges of the Panel or Curves defining the Opening are null.");
                 }
 
 

--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -278,7 +278,7 @@ namespace BH.Adapter.Lusas
                                 {                                    
                                     if (panel.ExternalEdges.All(x => !Engine.Adapters.Lusas.Query.InvalidEdge(x)))
                                     {
-                                        if (Engine.Spatial.Query.IsPlanar(panel, true, Tolerance.MacroDistance))
+                                        if (Engine.Spatial.Query.IsPlanar(panel, true, m_mergeTolerance))
                                         {
                                             for (int i = 0; i < panel.ExternalEdges.Count; i++)
                                             {
@@ -391,7 +391,7 @@ namespace BH.Adapter.Lusas
                         {
                             if (opening.Edges.All(x => !Engine.Adapters.Lusas.Query.InvalidEdge(x)))
                             {
-                                if (Engine.Spatial.Query.IsPlanar(opening, false, Tolerance.MacroDistance)) //Check if this works.
+                                if (Engine.Spatial.Query.IsPlanar(opening, false, m_mergeTolerance)) //Check if this works.
                                 {
                                         for (int i = 0; i < opening.Edges.Count; i++)
                                         {

--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -271,9 +271,7 @@ namespace BH.Adapter.Lusas
                         if (CheckPropertyError(panel, p => p.ExternalEdges))
                             if (CheckPropertyError(panel.ExternalEdges, e => e.Select(x => x.Curve)))
                                 if (panel.ExternalEdges.All(x => x != null) && panel.ExternalEdges.Select(x => x.Curve).All(y => y != null))
-                                {
-                                    if (panel.Openings.Count > 0)
-                                        Engine.Base.Compute.RecordWarning("Lusas_Toolkit does not support Panels with Openings. The Panel will be pushed if valid, the Openings will not be pushed.");
+                                {                                    
                                     if (panel.ExternalEdges.All(x => !Engine.Adapters.Lusas.Query.InvalidEdge(x)))
                                     {
                                         if (Engine.Spatial.Query.IsPlanar(panel, false, Tolerance.MacroDistance))
@@ -283,6 +281,9 @@ namespace BH.Adapter.Lusas
                                                 if (!CheckPropertyError(panel, p => panel.ExternalEdges[i]) && Engine.Adapters.Lusas.Query.InvalidEdge(panel.ExternalEdges[i]))
                                                     break;
 
+                                                if (panel.Openings.Count > 0)
+                                                    Engine.Base.Compute.RecordWarning("Lusas_Toolkit does not support Panels with Openings. The Panel will be pushed if valid, the Openings will not be pushed.");
+                                                
                                                 if (i == panel.ExternalEdges.Count - 1)
                                                     validPanels.Add(panel);
                                             }

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -28,11 +28,8 @@ using BH.oM.Adapters.Lusas.Fragments;
 using BH.Engine.Base;
 using System.Linq;
 using System.Collections.Generic;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
-using System.Windows.Forms.VisualStyles;
 using BH.Engine.Spatial;
 using BH.oM.Geometry;
-using System.Runtime.ExceptionServices;
 using BH.Engine.Geometry;
 
 namespace BH.Adapter.Lusas

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -30,6 +30,8 @@ using System.Linq;
 using System.Collections.Generic;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 using System.Windows.Forms.VisualStyles;
+using BH.Engine.Spatial;
+using BH.oM.Geometry;
 
 namespace BH.Adapter.Lusas
 {
@@ -80,10 +82,16 @@ namespace BH.Adapter.Lusas
 
                 if (string.IsNullOrEmpty(openingID))
                 {
-                    Engine.Base.Compute.RecordError("Could not find the ids for at least one Opening, that Opening not created.");
-                    return null;
+                    Engine.Base.Compute.RecordWarning("Could not find the ids for at least one Opening, Opening not created.");
+                    continue;
                 }
-                //Needed to create the opening in Lusas. 
+
+                if (Engine.Geometry.Query.IsCoplanar(opening.FitPlane(), panel.FitPlane(), Tolerance.MacroDistance))
+                {
+                    Engine.Base.Compute.RecordWarning("The geometry defining the Panel is not Coplanar with at least one Opening, Opening not created.");
+                    continue;   
+                }
+                
                 IFObjectSet lusasSelection = m_LusasApplication.newObjectSet();
                 IFGeometryData lusasGeometryData = m_LusasApplication.newGeometryData();
 

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -86,9 +86,9 @@ namespace BH.Adapter.Lusas
                     continue;
                 }
 
-                if (!Engine.Geometry.Query.IsCoplanar(opening.FitPlane(), panel.FitPlane(), Tolerance.MacroDistance))
+                if (!Engine.Geometry.Query.IsCoplanar(opening.FitPlane(), panel.FitPlane(), m_mergeTolerance))
                 {
-                    Engine.Base.Compute.RecordWarning("The geometry defining the Panel is not Coplanar with at least one Opening, Opening not created.");
+                    Engine.Base.Compute.RecordError("The geometry defining the Panel is not Coplanar with at least one Opening, Opening not created.");
                     continue;
                 }
                 
@@ -154,7 +154,7 @@ namespace BH.Adapter.Lusas
 
                 if (string.IsNullOrEmpty(edgeId))
                 {
-                    Engine.Base.Compute.RecordError("Could not find the ids for at least one Edge, Panel not created.");
+                    Engine.Base.Compute.RecordError("Could not find the ids for at least one Edge, Opening not created.");
                     return null;
                 }
                 else
@@ -165,7 +165,7 @@ namespace BH.Adapter.Lusas
 
             IFSurface lusasSurface = d_LusasData.createSurfaceBy(edges.ToArray());
 
-            if (lusasSurface != null) //Is this neccesary ?
+            if (lusasSurface != null)
             {
                 long adapterIdName = lusasSurface.getID();
                 opening.SetAdapterId(typeof(LusasId), adapterIdName);

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -82,7 +82,7 @@ namespace BH.Adapter.Lusas
 
                 if (string.IsNullOrEmpty(openingID))
                 {
-                    Engine.Base.Compute.RecordWarning("Could not find the ids for at least one Opening, Opening not created.");
+                    Engine.Base.Compute.RecordError($"Could not find the ids for at least one of the Openings on Surface {GetAdapterId<string>(panel)}, Opening not created.");
                     continue;
                 }
 

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -69,7 +69,7 @@ namespace BH.Adapter.Lusas
                 }
             }
 
-                    IFSurface lusasSurface = d_LusasData.createSurfaceBy(edges.ToArray());
+            IFSurface lusasSurface = d_LusasData.createSurfaceBy(edges.ToArray());
 
             if (panel.Openings.Count == 1) // Start testing with one opening. 
             {
@@ -89,8 +89,10 @@ namespace BH.Adapter.Lusas
                         internalEdges.Add(d_LusasData.getLineByNumber(edgeId));
                     }
                 }
+                //Create the internal Surface
                 IFSurface internalLusasSurface = d_LusasData.createSurfaceBy(internalEdges.ToArray());
 
+                //Creating information needed to create the hole in Lusas. 
                 IFObjectSet lusasSelection = m_LusasApplication.newObjectSet();
                 IFGeometryData lusasGeometryData = m_LusasApplication.newGeometryData();
 

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -86,10 +86,10 @@ namespace BH.Adapter.Lusas
                     continue;
                 }
 
-                if (Engine.Geometry.Query.IsCoplanar(opening.FitPlane(), panel.FitPlane(), Tolerance.MacroDistance))
+                if (!Engine.Geometry.Query.IsCoplanar(opening.FitPlane(), panel.FitPlane(), Tolerance.MacroDistance))
                 {
                     Engine.Base.Compute.RecordWarning("The geometry defining the Panel is not Coplanar with at least one Opening, Opening not created.");
-                    continue;   
+                    continue;
                 }
                 
                 IFObjectSet lusasSelection = m_LusasApplication.newObjectSet();

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -71,7 +71,7 @@ namespace BH.Adapter.Lusas
 
             IFSurface lusasSurface = d_LusasData.createSurfaceBy(edges.ToArray());
 
-            if (panel.Openings.Count > 0) // Start testing with one opening. 
+            if (panel.Openings.Count > 0) 
             {
                 //Creating information needed to create the hole in Lusas. 
                 IFObjectSet lusasSelection = m_LusasApplication.newObjectSet();

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -71,27 +71,8 @@ namespace BH.Adapter.Lusas
 
             IFSurface lusasSurface = d_LusasData.createSurfaceBy(edges.ToArray());
 
-            if (panel.Openings.Count == 1) // Start testing with one opening. 
+            if (panel.Openings.Count > 0) // Start testing with one opening. 
             {
-                List<IFLine> internalEdges = new List<IFLine>();
-
-                foreach (Edge edge in panel.Openings[0].Edges)
-                {
-                    string edgeId = GetAdapterId<string>(edge);
-
-                    if (string.IsNullOrEmpty(edgeId))
-                    {
-                        Engine.Base.Compute.RecordError("Could not find the ids for at least one internal Edge, Opening not created.");
-                        break;
-                    }
-                    else
-                    {
-                        internalEdges.Add(d_LusasData.getLineByNumber(edgeId));
-                    }
-                }
-                //Create the internal Surface
-                IFSurface internalLusasSurface = d_LusasData.createSurfaceBy(internalEdges.ToArray());
-
                 //Creating information needed to create the hole in Lusas. 
                 IFObjectSet lusasSelection = m_LusasApplication.newObjectSet();
                 IFGeometryData lusasGeometryData = m_LusasApplication.newGeometryData();
@@ -102,7 +83,29 @@ namespace BH.Adapter.Lusas
                 lusasGeometryData.trimDeleteTrimmingLinesOn();
 
                 lusasSelection.add(lusasSurface, "Surface");
-                lusasSelection.add(internalLusasSurface, "Surface");
+
+                for (int i = 0; i < panel.Openings.Count; i++)
+                {
+                    List<IFLine> internalEdges = new List<IFLine>();
+
+                    foreach (Edge edge in panel.Openings[i].Edges)
+                    {
+                        string edgeId = GetAdapterId<string>(edge);
+
+                        if (string.IsNullOrEmpty(edgeId))
+                        {
+                            Engine.Base.Compute.RecordError("Could not find the ids for at least one internal Edge, Opening not created.");
+                            break;
+                        }
+                        else
+                        {
+                            internalEdges.Add(d_LusasData.getLineByNumber(edgeId));
+                        }
+                    }
+                    //Create the internal Surface
+                    IFSurface internalLusasSurface = d_LusasData.createSurfaceBy(internalEdges.ToArray());
+                    lusasSelection.add(internalLusasSurface, "Surface");
+                }
 
                 lusasSelection.trim(lusasGeometryData);
             }

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -53,7 +53,7 @@ namespace BH.Adapter.Lusas
         {
             List<IFLine> edges = new List<IFLine>();
 
-            foreach(Edge edge in panel.ExternalEdges)
+            foreach (Edge edge in panel.ExternalEdges)
             {
                 string edgeId = GetAdapterId<string>(edge);
 
@@ -68,7 +68,29 @@ namespace BH.Adapter.Lusas
                 }
             }
 
-            IFSurface lusasSurface = d_LusasData.createSurfaceBy(edges.ToArray());
+                    IFSurface lusasSurface = d_LusasData.createSurfaceBy(edges.ToArray());
+
+            if (panel.Openings.Count == 1) // Start testing with one opening. 
+            {
+                List<IFLine> internalEdges = new List<IFLine>();
+
+                foreach (Edge edge in panel.Openings[0].Edges)
+                {
+                    string edgeId = GetAdapterId<string>(edge);
+
+                    if (string.IsNullOrEmpty(edgeId))
+                    {
+                        Engine.Base.Compute.RecordError("Could not find the ids for at least one internal Edge, Opening not created.");
+                        break;
+                    }
+                    else
+                    {
+                        internalEdges.Add(d_LusasData.getLineByNumber(edgeId));
+                    }
+                }
+                IFSurface internalLusasSurface = d_LusasData.createSurfaceBy(internalEdges.ToArray());
+                lusasSurface.trim(internalEdges);
+            }
 
             if (lusasSurface != null)
             {

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -28,6 +28,7 @@ using BH.oM.Adapters.Lusas.Fragments;
 using BH.Engine.Base;
 using System.Linq;
 using System.Collections.Generic;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace BH.Adapter.Lusas
 {
@@ -89,7 +90,19 @@ namespace BH.Adapter.Lusas
                     }
                 }
                 IFSurface internalLusasSurface = d_LusasData.createSurfaceBy(internalEdges.ToArray());
-                lusasSurface.trim(internalEdges);
+
+                IFObjectSet lusasSelection = m_LusasApplication.newObjectSet();
+                IFGeometryData lusasGeometryData = m_LusasApplication.newGeometryData();
+
+                lusasGeometryData.setAllDefaults();
+                lusasGeometryData.trimOuterBoundaryOff();
+                lusasGeometryData.trimDeleteOuterBoundaryOff();
+                lusasGeometryData.trimDeleteTrimmingLinesOn();
+
+                lusasSelection.add(lusasSurface, "Surface");
+                lusasSelection.add(internalLusasSurface, "Surface");
+
+                lusasSelection.trim(lusasGeometryData);
             }
 
             if (lusasSurface != null)

--- a/Lusas_Adapter/CRUD/Read/Elements/Openings.cs
+++ b/Lusas_Adapter/CRUD/Read/Elements/Openings.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
  *
@@ -30,6 +30,8 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.MaterialFragments;
 using BH.Engine.Adapter;
 using Lusas.LPI;
+using BH.oM.Physical.Materials;
+using System.Windows.Forms.VisualStyles;
 
 namespace BH.Adapter.Lusas
 {
@@ -51,57 +53,35 @@ namespace BH.Adapter.Lusas
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private List<Panel> ReadPanels(List<string> ids = null)
+        private List<Opening> ReadOpenings(List<string> ids = null)
         {
             object[] lusasSurfaces = d_LusasData.getObjects("Surface");
-            List<Panel> panels = new List<Panel>();
+            List<Opening> openings = new List<Opening>();
 
             if (!(lusasSurfaces.Count() == 0))
             {
                 IEnumerable<Edge> edgesList = GetCachedOrRead<Edge>();
                 Dictionary<string, Edge> edges = edgesList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
 
-                IEnumerable<Opening> openingsList = GetCachedOrRead<Opening>();
-                Dictionary<string, Opening> openings = openingsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
-
                 HashSet<string> groupNames = ReadTags();
 
-                IEnumerable<IMaterialFragment> materialList = GetCachedOrRead<IMaterialFragment>();
-                Dictionary<string, IMaterialFragment> materials = materialList.ToDictionary(x => x.Name.ToString());
-
-                IEnumerable<ISurfaceProperty> sectionPropertiesList = GetCachedOrRead<ISurfaceProperty>();
-                Dictionary<string, ISurfaceProperty> sectionProperties = sectionPropertiesList.ToDictionary(x => x.Name.ToString());
-
-                IEnumerable<Constraint4DOF> supportsList = GetCachedOrRead<Constraint4DOF>();
-                Dictionary<string, Constraint4DOF> supports = supportsList.ToDictionary(x => x.Name);
-
-                List<MeshSettings2D> meshesList = GetCachedOrRead<MeshSettings2D>();
-                Dictionary<string, MeshSettings2D> meshes = meshesList.ToDictionary(x => x.Name.ToString());
 
                 for (int i = 0; i < lusasSurfaces.Count(); i++)
                 {
                     IFSurface lusasSurface = (IFSurface)lusasSurfaces[i];
-                    Panel panel = Adapters.Lusas.Convert.ToPanel(lusasSurface,
-                        edges,
-                        openings,
-                        groupNames,
-                        sectionProperties,
-                        materials,
-                        supports,
-                        meshes);
+                    for (int j = 1; j < lusasSurface.countBoundaries(); j++)
+                    {
+                        Opening opening = Adapters.Lusas.Convert.ToOpening(lusasSurface, j, edges, groupNames);
 
-                    panels.Add(panel);
+                        openings.Add(opening);
+                    }
                 }
             }
 
-            return panels;
+            return openings;
         }
 
         /***************************************************/
 
     }
 }
-
-
-
-

--- a/Lusas_Adapter/CRUD/Read/Read.cs
+++ b/Lusas_Adapter/CRUD/Read/Read.cs
@@ -71,6 +71,8 @@ namespace BH.Adapter.Lusas
                 return ReadEdges(ids as dynamic);
             else if (type == typeof(Point))
                 return ReadPoints(ids as dynamic);
+            else if (type == typeof(Opening))
+                return ReadOpenings(ids as dynamic);
             else if (type == typeof(Constraint6DOF))
                 return Read6DOFConstraints(ids as dynamic);
             else if (type == typeof(Constraint4DOF))

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToOpening.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToOpening.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Adapters.Lusas.Fragments;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.SurfaceProperties;
+using BH.oM.Structure.Constraints;
+using BH.oM.Geometry;
+using BH.oM.Structure.MaterialFragments;
+using Lusas.LPI;
+using BH.oM.Adapters.Lusas;
+using BH.Engine.Adapter;
+using BH.Engine.Base;
+
+namespace BH.Adapter.Adapters.Lusas
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Opening ToOpening(this IFSurface lusasSurface,
+            int boundaryIndex,
+            Dictionary<string, Edge> edges,
+            HashSet<string> groupNames
+            )
+
+        {
+            object[] lusasSurfaceLines = lusasSurface.getBoundaryLOFs(boundaryIndex);
+
+            HashSet<string> tags = new HashSet<string>(IsMemberOf(lusasSurface, groupNames));
+
+            //No create method taking edges. Using curves and joining them instead.
+            //FIX Why it does not give me a closed curve here.
+            List<ICurve> openingEdges = new List<ICurve>();
+
+            for (int i = 0; i < lusasSurfaceLines.Length; i++)
+            {
+                Edge edge = GetInnerEdge(lusasSurface, boundaryIndex, i, edges);
+                openingEdges.Add(edge.Curve);
+            }
+       
+            Opening opening = Engine.Structure.Create.Opening(openingEdges);
+
+            opening.Tags = tags;
+
+            string adapterID = lusasSurface.getID().ToString() + "_" + boundaryIndex.ToString();
+            opening.SetAdapterId(typeof(LusasId), adapterID);
+
+            return opening;
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+       private static Edge GetInnerEdge(IFSurface lusasSurf, int boundaryIndex, int lineIndex, Dictionary<string, Edge> edges)
+        {
+            Edge edge;
+            IFLine lusasEdge = lusasSurf.getBoundaryLOFs(boundaryIndex)[lineIndex];
+            edges.TryGetValue(lusasEdge.getID().ToString(), out edge);
+            return edge;
+        }
+ 
+        /***************************************************/
+
+    }
+}

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToOpening.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToOpening.cs
@@ -52,8 +52,6 @@ namespace BH.Adapter.Adapters.Lusas
 
             HashSet<string> tags = new HashSet<string>(IsMemberOf(lusasSurface, groupNames));
 
-            //No create method taking edges. Using curves and joining them instead.
-            //FIX Why it does not give me a closed curve here.
             List<ICurve> openingEdges = new List<ICurve>();
 
             for (int i = 0; i < lusasSurfaceLines.Length; i++)
@@ -66,6 +64,7 @@ namespace BH.Adapter.Adapters.Lusas
 
             opening.Tags = tags;
 
+            //Takes both the ID of the surface and the index of the "hole" from Lusas.
             string adapterID = lusasSurface.getID().ToString() + "_" + boundaryIndex.ToString();
             opening.SetAdapterId(typeof(LusasId), adapterID);
 

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToOpening.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToOpening.cs
@@ -59,9 +59,9 @@ namespace BH.Adapter.Adapters.Lusas
             for (int i = 0; i < lusasSurfaceLines.Length; i++)
             {
                 Edge edge = GetInnerEdge(lusasSurface, boundaryIndex, i, edges);
-                openingEdges.Add(edge.Curve);
+                openingEdges.Insert(0, edge.Curve);
             }
-       
+            
             Opening opening = Engine.Structure.Create.Opening(openingEdges);
 
             opening.Tags = tags;

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToPanel.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToPanel.cs
@@ -43,6 +43,7 @@ namespace BH.Adapter.Adapters.Lusas
 
         public static Panel ToPanel(this IFSurface lusasSurface,
             Dictionary<string, Edge> edges,
+            Dictionary<string, Opening> openings,
             HashSet<string> groupNames,
             Dictionary<string, ISurfaceProperty> surfaceProperties,
             Dictionary<string, IMaterialFragment> materials,
@@ -64,6 +65,16 @@ namespace BH.Adapter.Adapters.Lusas
             }
 
             Panel panel = Engine.Structure.Create.Panel(surfaceEdges);
+
+            List<Opening> panelOpenings = new List<Opening>();
+
+            for (int i = 1; i < lusasSurface.countBoundaries(); i++)
+            {
+                Opening opening = GetOpening(lusasSurface.getID(), i, openings);
+                panelOpenings.Add(opening);
+            }
+
+            panel.Openings = panelOpenings;
 
             panel.Tags = tags;
 
@@ -110,6 +121,13 @@ namespace BH.Adapter.Adapters.Lusas
             IFLine lusasEdge = lusasSurf.getBoundaryLOFs(0)[lineIndex];
             bars.TryGetValue(lusasEdge.getID().ToString(), out edge);
             return edge;
+        }
+
+        private static Opening GetOpening(int surfaceID, int boundaryIndex, Dictionary<string, Opening> openings)
+        {
+            Opening opening;
+            openings.TryGetValue(surfaceID.ToString()+"_"+boundaryIndex.ToString(), out opening);
+            return opening;
         }
 
         /***************************************************/

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToPanel.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToPanel.cs
@@ -70,7 +70,7 @@ namespace BH.Adapter.Adapters.Lusas
 
             for (int i = 1; i < lusasSurface.countBoundaries(); i++)
             {
-                Opening opening = GetOpening(lusasSurface.getID(), i, openings);
+                Opening opening = GetOpening((int)lusasSurface.getID(), i, openings);
                 panelOpenings.Add(opening);
             }
 

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToPanel.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToPanel.cs
@@ -126,7 +126,7 @@ namespace BH.Adapter.Adapters.Lusas
         private static Opening GetOpening(int surfaceID, int boundaryIndex, Dictionary<string, Opening> openings)
         {
             Opening opening;
-            openings.TryGetValue(surfaceID.ToString()+"_"+boundaryIndex.ToString(), out opening);
+            openings.TryGetValue(surfaceID.ToString() + "_" + boundaryIndex.ToString(), out opening);
             return opening;
         }
 

--- a/Lusas_Adapter/Convert/ToBHoM/Elements/ToPanel.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Elements/ToPanel.cs
@@ -50,7 +50,7 @@ namespace BH.Adapter.Adapters.Lusas
             Dictionary<string, MeshSettings2D> meshes)
 
         {
-            object[] lusasSurfaceLines = lusasSurface.getLOFs();
+            object[] lusasSurfaceLines = lusasSurface.getBoundaryLOFs(0);
 
             int n = lusasSurfaceLines.Length;
             HashSet<string> tags = new HashSet<string>(IsMemberOf(lusasSurface, groupNames));
@@ -59,7 +59,7 @@ namespace BH.Adapter.Adapters.Lusas
 
             for (int i = 0; i < n; i++)
             {
-                Edge edge = GetEdge(lusasSurface, i, edges);
+                Edge edge = GetOuterEdge(lusasSurface, i, edges);
                 surfaceEdges.Add(edge);
             }
 
@@ -104,10 +104,10 @@ namespace BH.Adapter.Adapters.Lusas
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private static Edge GetEdge(IFSurface lusasSurf, int lineIndex, Dictionary<string, Edge> bars)
+        private static Edge GetOuterEdge(IFSurface lusasSurf, int lineIndex, Dictionary<string, Edge> bars)
         {
             Edge edge;
-            IFLine lusasEdge = lusasSurf.getLOFs()[lineIndex];
+            IFLine lusasEdge = lusasSurf.getBoundaryLOFs(0)[lineIndex];
             bars.TryGetValue(lusasEdge.getID().ToString(), out edge);
             return edge;
         }

--- a/Lusas_Adapter/LusasAdapter.cs
+++ b/Lusas_Adapter/LusasAdapter.cs
@@ -129,6 +129,7 @@ namespace BH.Adapter.Lusas
                 DependencyTypes = new Dictionary<Type, List<Type>>
                 {
                     {typeof(Panel), new List<Type> { typeof(ISurfaceProperty), typeof(Edge), typeof(Opening) } },
+                    {typeof(Opening), new List<Type> {typeof(Edge) } },
                     {typeof(Edge), new List<Type> { typeof(Constraint4DOF), typeof(Constraint6DOF) } },
                     {typeof(Bar), new List<Type> { typeof(Node) , typeof(ISectionProperty), typeof(Constraint4DOF) } },
                     {typeof(Node), new List<Type> { typeof(Constraint6DOF) } },

--- a/Lusas_Adapter/LusasAdapter.cs
+++ b/Lusas_Adapter/LusasAdapter.cs
@@ -128,7 +128,7 @@ namespace BH.Adapter.Lusas
 
                 DependencyTypes = new Dictionary<Type, List<Type>>
                 {
-                    {typeof(Panel), new List<Type> { typeof(ISurfaceProperty), typeof(Edge)} },
+                    {typeof(Panel), new List<Type> { typeof(ISurfaceProperty), typeof(Edge), typeof(Opening) } },
                     {typeof(Edge), new List<Type> { typeof(Constraint4DOF), typeof(Constraint6DOF) } },
                     {typeof(Bar), new List<Type> { typeof(Node) , typeof(ISectionProperty), typeof(Constraint4DOF) } },
                     {typeof(Node), new List<Type> { typeof(Constraint6DOF) } },

--- a/Lusas_Adapter/Lusas_Adapter.csproj
+++ b/Lusas_Adapter/Lusas_Adapter.csproj
@@ -594,6 +594,7 @@
     <Compile Include="Convert\ToBHoM\Elements\ToBar.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToEdge.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToNode.cs" />
+    <Compile Include="Convert\ToBHoM\Elements\ToOpening.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToPanel.cs" />
     <Compile Include="Convert\ToBHoM\Elements\ToPoint.cs" />
     <Compile Include="Convert\ToBHoM\Loads\ToAreaUniformTemperatureLoad.cs" />
@@ -657,6 +658,7 @@
     <Compile Include="CRUD\Delete\Property\SectionProperties.cs" />
     <Compile Include="CRUD\Delete\Property\SurfaceProperties.cs" />
     <Compile Include="CRUD\Delete\Delete.cs" />
+    <Compile Include="CRUD\Read\Elements\Openings.cs" />
     <Compile Include="CRUD\Read\Results\BarResults.cs" />
     <Compile Include="CRUD\Read\Results\MeshResults.cs" />
     <Compile Include="CRUD\Read\Results\NodeResults.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->



   
### Issues addressed by this PR

Closes #226 

<!-- Add short description of what has been fixed -->
Support has been added to the adapter to `Push` and `Pull` `Panel` with `Openings`



### Test files
<!-- Link to test files to validate the proposed changes -->
Test file for Grasshopper. Tests a number of different panel and opening configurations. 
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Lusas_Toolkit/%23396-AddSupportForPanelWithOpenings?csf=1&web=1&e=gfan72

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added `Opening` as dependency type to `Panel`.
- Added `CreateCollection` method for type `Opening` in `Lusas_Adapter`.
- Change in `CreateSurface` method to create Lusas "hole".
- Change in `ReadPanels` to include `Openings`.
- Added `CreateSurface` method for type `Opening`.
- Added `ReadOpenings` method in `Lusas_Adapter`.
- Added type `Opening` to `Read` and `ReadAll` in `Lusas_Adapter`.
- Change in `Convert` `ToPanel` method to include `Openings`.
- Added a `Convert` method for `Openings`. 


### Additional comments
<!-- As required -->