### PR TITLE
Fix error message and default merge tolerance

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -88,14 +88,14 @@ namespace BH.Adapter.Lusas
 
                 if (EdgeIntersection(opening.Edges, panel.ExternalEdges))
                 {
-                    Engine.Base.Compute.RecordError($"At least one Edge defining the Panel {lusasSurface.getID()} intersects with at least one Edge defining the Opening {openingID}, Opening not created.");
+                    Engine.Base.Compute.RecordError($"At least one Edge defining the Panel {lusasSurface.getID()} intersects with at least one Edge defining the Opening, Opening not created.");
                     continue;
                 }
                    
 
                 if (!Engine.Geometry.Query.IsCoplanar(opening.FitPlane(), panel.FitPlane(), m_mergeTolerance))
                 {
-                    Engine.Base.Compute.RecordError($"The geometry defining the Panel {lusasSurface.getID()} is not Coplanar with the Opening {openingID}, Opening not created.");
+                    Engine.Base.Compute.RecordError($"The geometry defining the Panel {lusasSurface.getID()} is not Coplanar with the Opening, Opening not created.");
                     continue;
                 }
                 

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -81,7 +81,7 @@ namespace BH.Adapter.Lusas
 
                 if (string.IsNullOrEmpty(openingID))
                 {
-                    Engine.Base.Compute.RecordError($"Could not find the ids for at least one of the Openings on Surface {lusasSurface.getID()}, Opening not created.");
+                    Engine.Base.Compute.RecordError($"Could not find the ids for at least one of the Openings on Panel {lusasSurface.getID()}, this Opening has not been created.");
                     continue;
                 }
 

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -88,7 +88,7 @@ namespace BH.Adapter.Lusas
 
                 if (EdgeIntersection(opening.Edges, panel.ExternalEdges))
                 {
-                    Engine.Base.Compute.RecordError($"At least one Edge defining the Panel {lusasSurface.getID()} intersects with at least one Edge defining the Opening, Opening not created.");
+                    Engine.Base.Compute.RecordError($"At least one Edge defining Panel {lusasSurface.getID()} intersects with at least one Edge defining an Opening, this Opening has not been created.");
                     continue;
                 }
                    

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -81,21 +81,21 @@ namespace BH.Adapter.Lusas
 
                 if (string.IsNullOrEmpty(openingID))
                 {
-                    Engine.Base.Compute.RecordError($"Could not find the ids for at least one of the Openings on Surface {GetAdapterId<string>(panel)}, Opening not created.");
+                    Engine.Base.Compute.RecordError($"Could not find the ids for at least one of the Openings on Surface {lusasSurface.getID()}, Opening not created.");
                     continue;
                 }
 
 
                 if (EdgeIntersection(opening.Edges, panel.ExternalEdges))
                 {
-                    Engine.Base.Compute.RecordError($"At least one Edge defining the Panel {GetAdapterId<string>(panel)} intersects with at least one Edge defining the Opening {GetAdapterId<string>(opening)}, Opening not created.");
+                    Engine.Base.Compute.RecordError($"At least one Edge defining the Panel {lusasSurface.getID()} intersects with at least one Edge defining the Opening {openingID}, Opening not created.");
                     continue;
                 }
                    
 
                 if (!Engine.Geometry.Query.IsCoplanar(opening.FitPlane(), panel.FitPlane(), m_mergeTolerance))
                 {
-                    Engine.Base.Compute.RecordError($"The geometry defining the Panel {GetAdapterId<string>(panel)} is not Coplanar the Opening {GetAdapterId<string>(opening)}, Opening not created.");
+                    Engine.Base.Compute.RecordError($"The geometry defining the Panel {lusasSurface.getID()} is not Coplanar with the Opening {openingID}, Opening not created.");
                     continue;
                 }
                 
@@ -148,10 +148,6 @@ namespace BH.Adapter.Lusas
 
             return lusasSurface;
         }
-
-        /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
 
         private static bool EdgeIntersection(List<Edge> openingEdges, List<Edge> panelEdges)
         {

--- a/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
+++ b/Lusas_Adapter/CRUD/Create/Elements/Surface.cs
@@ -95,7 +95,7 @@ namespace BH.Adapter.Lusas
 
                 if (!Engine.Geometry.Query.IsCoplanar(opening.FitPlane(), panel.FitPlane(), m_mergeTolerance))
                 {
-                    Engine.Base.Compute.RecordError($"The geometry defining the Panel {lusasSurface.getID()} is not Coplanar with the Opening, Opening not created.");
+                    Engine.Base.Compute.RecordError($"The geometry defining Panel {lusasSurface.getID()} is not Coplanar with an Opening, this Opening has not been created.");
                     continue;
                 }
                 

--- a/Lusas_Adapter/LusasAdapter.cs
+++ b/Lusas_Adapter/LusasAdapter.cs
@@ -198,7 +198,7 @@ namespace BH.Adapter.Lusas
         //Add any comlink object as a private field here, example named:
 
         private string m_directory;
-        public double m_mergeTolerance = double.NaN;
+        public double m_mergeTolerance = Tolerance.Distance;
         public double m_g = 9.80665;
         public LusasWinApp m_LusasApplication;
         public IFDatabase d_LusasData;

--- a/Lusas_Adapter/LusasAdapter.cs
+++ b/Lusas_Adapter/LusasAdapter.cs
@@ -176,6 +176,10 @@ namespace BH.Adapter.Lusas
                         m_mergeTolerance = lusasSettings.MergeTolerance;
                         d_LusasData.getOptions().setDouble("TOLMRG", m_mergeTolerance);
                     }
+                    else
+                    {
+                        Engine.Base.Compute.RecordWarning($"A merge tolerance has not been set and the default value of {Tolerance.Distance} has been used.");
+                    }
 
                     if (lusasSettings != null) { m_g = lusasSettings.StandardGravity; }
                 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #397 
Closes #398 

<!-- Add short description of what has been fixed -->
Fixed two bug related to Panel with openings. Giving m_mergeTolerance a default value and correcting Ids in Error message.



### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Lusas_Toolkit/%23396-AddSupportForPanelWithOpenings?csf=1&web=1&e=uOsKNh


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added default value for `m_mergeTolerance` to be `Tolerance.Distance` (1E-6).
- Changed Ids in Error message regarding invalid `Openings` in `Create`/`Surface.cs` 
