### PR TITLE
Fixes bug whereby pulling a MeshSettings1D with div = 1 returns an error

### DIFF
--- a/Lusas_Adapter/Convert/ToBHoM/Properties/ToMeshSettings1D.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Properties/ToMeshSettings1D.cs
@@ -59,7 +59,7 @@ namespace BH.Adapter.Adapters.Lusas
             else if (meshType == 1)
             {
                 splitMethod = Split1D.Divisions;
-                object[] ratios = lusasMeshLine.getValue("ratio");
+                object[] ratios = lusasMeshLine.getMeshDivisions(0);
                 value = ratios.Count();
                 if (value == 0)
                     value = 4;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #404 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/Lusas_Toolkit/%23404%20Pull%20MeshSettings1D/PullMeshSettings1D.gh?csf=1&web=1&e=zU6eQp

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

### Additional comments
<!-- As required -->