### PR TITLE
New support to pull back bar results

### DIFF
--- a/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
@@ -27,14 +27,8 @@ using BH.oM.Structure.Results;
 using System.Collections.Generic;
 using System.Linq;
 using Lusas.LPI;
-using BH.oM.Structure.Elements;
-using BH.Engine.Base;
-using BH.oM.Geometry;
-using Microsoft.SqlServer.Server;
 using BH.Adapter.Adapters.Lusas;
-using BH.oM.Structure.Constraints;
-using System.Dynamic;
-using System.ComponentModel;
+
 
 namespace BH.Adapter.Lusas
 {

--- a/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
@@ -28,8 +28,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Lusas.LPI;
 
-using BH.Adapter.Adapters.Lusas;
-
 
 
 namespace BH.Adapter.Lusas
@@ -160,8 +158,10 @@ namespace BH.Adapter.Lusas
                 List<string> componentsBar = new List<string>() {"Fx"};
 
                 d_LusasData.startUsingScriptedResults();
+
                 Dictionary<string, IFResultsComponentSet> resultsSetsBeam = new Dictionary<string, IFResultsComponentSet>();
                 Dictionary<string, IFResultsComponentSet> resultsSetsBar = new Dictionary<string, IFResultsComponentSet>();
+
                 if (beamIds.Count()>0==true)
                     resultsSetsBeam = GetResultsSets(entityBeam, componentsBeam, location, resultsContext);
                 if (barIds.Count() > 0 == true)
@@ -172,6 +172,11 @@ namespace BH.Adapter.Lusas
                 foreach (int id in ids)
                 {
                     Dictionary<string, double> featureResults = new Dictionary<string, double>();
+
+                    if (barIds.Contains(id))
+                        featureResults = GetFeatureResults(componentsBar, resultsSetsBar, unitSet, id, "L", 6);
+                    if (beamIds.Contains(id))
+                        featureResults = GetFeatureResults(componentsBeam, resultsSetsBeam, unitSet, id, "L", 6);
 
                     double fX = 0; double fY = 0; double fZ = 0; double mX = 0; double mY = 0; double mZ = 0;
                     if (beamIds.Contains(id))

--- a/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
@@ -142,10 +142,9 @@ namespace BH.Adapter.Lusas
                 }
             }    
      
-            if (beamIds.Count()==0)
-               BH.Engine.Base.Compute.RecordWarning("No BeamIds were pulled");
-            if (barIds.Count() == 0)
-                BH.Engine.Base.Compute.RecordWarning("No BarIds were pulled");
+            if (beamIds.Count() + barIds.Count() == 0)
+               BH.Engine.Base.Compute.RecordError("No matching IDs found");
+            
             foreach (int loadcaseId in loadcaseIds)
             {
                 IFLoadset loadset = d_LusasData.getLoadset(loadcaseId);

--- a/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
@@ -140,11 +140,14 @@ namespace BH.Adapter.Lusas
                         }
                     }
                 }
-            }    
-     
+            }
+
             if (beamIds.Count() + barIds.Count() == 0)
-               BH.Engine.Base.Compute.RecordError("No matching IDs found");
-            
+            {
+                BH.Engine.Base.Compute.RecordWarning("The element type does not match the types currently supported, the adapter will attempt to pull results for a Thick 3D Beam");
+                beamIds = ids;
+            }
+
             foreach (int loadcaseId in loadcaseIds)
             {
                 IFLoadset loadset = d_LusasData.getLoadset(loadcaseId);
@@ -169,7 +172,7 @@ namespace BH.Adapter.Lusas
                 if (beamIds.Count()>0==true)
                     resultsSetsBeams = GetResultsSets(entityBeam, componentsBeam, location, resultsContext);
                 if (barIds.Count() > 0 == true)
-                    resultsSetsBars.Add("Fx", d_LusasData.getResultsComponentSet(entityBar, "Fx" , location, resultsContext));
+                    resultsSetsBars.Add(componentsBar[0], d_LusasData.getResultsComponentSet(entityBar, componentsBar[0] , location, resultsContext));
 
                 foreach (int id in ids)
                 {

--- a/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
@@ -145,7 +145,7 @@ namespace BH.Adapter.Lusas
             if (beamIds.Count() + barIds.Count() == 0)
             {
                 BH.Engine.Base.Compute.RecordWarning("The element type does not match the types currently supported, the adapter will attempt to pull results for a Thick 3D Beam");
-                beamIds = ids;
+                 beamIds = ids;
             }
 
             foreach (int loadcaseId in loadcaseIds)

--- a/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
@@ -91,7 +91,8 @@ namespace BH.Adapter.Lusas
             IFView view = m_LusasApplication.getCurrentView();
             IFResultsContext resultsContext = m_LusasApplication.newResultsContext(view);
 
-            string entity = "Force/Moment - Thick 3D Beam";
+            string entityBeam = "Force/Moment - Thick 3D Beam";
+            string entityBar = "Force/Moment - Bar";
             string location = "Feature extreme";
 
             foreach (int loadcaseId in loadcaseIds)
@@ -108,9 +109,11 @@ namespace BH.Adapter.Lusas
                 double lengthSIConversion = 1 / unitSet.getLengthFactor();
 
                 List<string> components = new List<string>() { "Fx", "Fy", "Fz", "Mx", "My", "Mz" };
+                List<string> components2 = new List<string>() {"Fx"};
                 d_LusasData.startUsingScriptedResults();
 
-                Dictionary<string, IFResultsComponentSet> resultsSets = GetResultsSets(entity, components, location, resultsContext);
+                Dictionary<string, IFResultsComponentSet> resultsSets = GetResultsSets(entityBar, components2, location, resultsContext);
+                
 
                 foreach (int barId in ids)
                 {

--- a/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Lusas_Adapter/CRUD/Read/Results/BarResults.cs
@@ -27,7 +27,9 @@ using BH.oM.Structure.Results;
 using System.Collections.Generic;
 using System.Linq;
 using Lusas.LPI;
+
 using BH.Adapter.Adapters.Lusas;
+
 
 
 namespace BH.Adapter.Lusas
@@ -92,12 +94,11 @@ namespace BH.Adapter.Lusas
 
             IFView view = m_LusasApplication.getCurrentView();
             IFResultsContext resultsContext = m_LusasApplication.newResultsContext(view);
+
             string entityBeam = "Force/Moment - Thick 3D Beam";
             string entityBar = "Force/Moment - Bar";
             string location = "Feature extreme";
 
-            // Extract the BarType for all ids provided
-            // List ids for beams, and ids for bars
             List<int> barIds = new List<int>();
             List<int> beamIds = new List<int>();
             foreach (int id in ids)
@@ -156,25 +157,21 @@ namespace BH.Adapter.Lusas
                 double lengthSIConversion = 1 / unitSet.getLengthFactor();
 
                 List<string> componentsBeam = new List<string>() { "Fx", "Fy", "Fz", "Mx", "My", "Mz" };
-                List<string> componentsBar = new List<string>() { "Fx" };
+                List<string> componentsBar = new List<string>() {"Fx"};
 
                 d_LusasData.startUsingScriptedResults();
-                Dictionary<string, IFResultsComponentSet> resultsSetsBeams = new Dictionary<string, IFResultsComponentSet>();
-                Dictionary<string, IFResultsComponentSet> resultsSetsBars = new Dictionary<string, IFResultsComponentSet>();
-
-                // if statement if count of list for Beams > 0
+                Dictionary<string, IFResultsComponentSet> resultsSetsBeam = new Dictionary<string, IFResultsComponentSet>();
+                Dictionary<string, IFResultsComponentSet> resultsSetsBar = new Dictionary<string, IFResultsComponentSet>();
                 if (beamIds.Count()>0==true)
-                    resultsSetsBeams = GetResultsSets(entityBeam, componentsBeam, location, resultsContext);
+                    resultsSetsBeam = GetResultsSets(entityBeam, componentsBeam, location, resultsContext);
                 if (barIds.Count() > 0 == true)
-                    resultsSetsBars.Add(componentsBar[0], d_LusasData.getResultsComponentSet(entityBar, componentsBar[0] , location, resultsContext));
+                    resultsSetsBar.Add(componentsBar[0], d_LusasData.getResultsComponentSet(entityBar, componentsBar[0] , location, resultsContext));
+
+                
 
                 foreach (int id in ids)
                 {
                     Dictionary<string, double> featureResults = new Dictionary<string, double>();
-                    if (barIds.Contains(id))
-                        featureResults=GetFeatureResults(componentsBar, resultsSetsBars, unitSet, id, "L", 6);
-                    if (beamIds.Contains(id))
-                        featureResults = GetFeatureResults(componentsBeam, resultsSetsBeams, unitSet, id, "L", 6);
 
                     double fX = 0; double fY = 0; double fZ = 0; double mX = 0; double mY = 0; double mZ = 0;
                     if (beamIds.Contains(id))
@@ -206,11 +203,12 @@ namespace BH.Adapter.Lusas
                         mZ * forceSIConversion * lengthSIConversion
                         );
                     barForces.Add(barForce);
-                }
-            }
 
-            d_LusasData.stopUsingScriptedResults();
-            d_LusasData.flushScriptedResults();
+                }
+
+                d_LusasData.stopUsingScriptedResults();
+                d_LusasData.flushScriptedResults();
+            }
 
             return barForces;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #414

Added new support to pull back results from axial elements 


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Lusas_Toolkit/%23418-AddSupportForBarResults?csf=1&web=1&e=o9DV0E


### Changelog
New method to sort the element ids into categories. 
Separate methods for pulling back results for beams and for bars 
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->