### PR TITLE
Add null check for `MeshSettings1D` and `MeshSettings2D`.

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -242,7 +242,8 @@ namespace BH.Adapter.Lusas
 
                         foreach (MeshSettings1D mesh in distinctMeshes)
                         {
-                            CreateMeshSettings1D(mesh, barGroup.First().FEAType, barGroup.First().Release);
+                            if (mesh != null)
+                                CreateMeshSettings1D(mesh, barGroup.First().FEAType, barGroup.First().Release);
                         }
 
                         foreach (Bar bar in barGroup)
@@ -284,7 +285,7 @@ namespace BH.Adapter.Lusas
                         if (CheckPropertyError(panel, p => p.ExternalEdges))
                             if (CheckPropertyError(panel.ExternalEdges, e => e.Select(x => x.Curve)))
                                 if (panel.ExternalEdges.All(x => x != null) && panel.ExternalEdges.Select(x => x.Curve).All(y => y != null))
-                                {                                    
+                                {
                                     if (panel.ExternalEdges.All(x => !Engine.Adapters.Lusas.Query.InvalidEdge(x)))
                                     {
                                         if (Engine.Spatial.Query.IsPlanar(panel, true, m_mergeTolerance))
@@ -319,7 +320,11 @@ namespace BH.Adapter.Lusas
                         .ToList();
 
                     foreach (MeshSettings2D mesh in distinctMeshes)
-                        CreateMeshSettings2D(mesh);
+                    {
+                        if(mesh != null)
+                            CreateMeshSettings2D(mesh);
+                    }
+
 
                     foreach (Panel validPanel in validPanels)
                         validPanel.AddFragment(distinctMeshes.First(x => comparer.Equals(x, (validPanel.FindFragment<MeshSettings2D>()))), true);
@@ -402,14 +407,14 @@ namespace BH.Adapter.Lusas
                             {
                                 if (Engine.Spatial.Query.IsPlanar(opening, false, m_mergeTolerance)) //Check if this works.
                                 {
-                                        for (int i = 0; i < opening.Edges.Count; i++)
-                                        {
-                                            if (!CheckPropertyError(opening, p => opening.Edges[i]) && Engine.Adapters.Lusas.Query.InvalidEdge(opening.Edges[i]))
-                                                break;
+                                    for (int i = 0; i < opening.Edges.Count; i++)
+                                    {
+                                        if (!CheckPropertyError(opening, p => opening.Edges[i]) && Engine.Adapters.Lusas.Query.InvalidEdge(opening.Edges[i]))
+                                            break;
 
-                                            if (i == opening.Edges.Count - 1)
-                                                validOpenings.Add(opening);
-                                        }                               
+                                        if (i == opening.Edges.Count - 1)
+                                            validOpenings.Add(opening);
+                                    }
                                 }
                                 else
                                     Engine.Base.Compute.RecordError("The geometry defining one of the Openings of the Panel is not Planar, and therefore the Opening will not be created.");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #443

<!-- Add short description of what has been fixed -->
- Added `null` checks when pushing `MeshSettings1D` and `MeshSettings2D`.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Lusas_Toolkit/%23444-MeshSettings1DBug?csf=1&web=1&e=GvI1jn

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->