### PR TITLE
Add push/pull support for `BarDifferentialTempatureLoad` and `AreaDifferentialTemperatureLoad`

### DIFF
--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -140,6 +140,12 @@ namespace BH.Adapter.Lusas
                         case "BH.oM.Structure.Loads.AreaUniformTemperatureLoad":
                             success = CreateCollection(objects as IEnumerable<AreaUniformTemperatureLoad>);
                             break;
+                        case "BH.oM.Structure.Loads.BarDifferentialTemperatureLoad":
+                            success = CreateCollection(objects as IEnumerable<BarDifferentialTemperatureLoad>);
+                            break;
+                        case "BH.oM.Structure.Loads.AreaDifferentialTemperatureLoad":
+                            success = CreateCollection(objects as IEnumerable<AreaDifferentialTemperatureLoad>);
+                            break;
                         case "BH.oM.Structure.Loads.PointDisplacement":
                             success = CreateCollection(objects as IEnumerable<PointDisplacement>);
                             break;
@@ -629,6 +635,44 @@ namespace BH.Adapter.Lusas
                     CreateAreaUniformTemperatureLoad(areaUniformTemperatureLoad, assignedLines);
 
                 if (lusasAreaUniformTemperatureLoad == null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        private bool CreateCollection(IEnumerable<BarDifferentialTemperatureLoad> barDifferentialTemperatureLoads)
+        {
+            foreach (BarDifferentialTemperatureLoad barDifferentialTemperatureLoad in barDifferentialTemperatureLoads)
+            {
+                object[] assignedLines = GetAssignedLines(barDifferentialTemperatureLoad);
+                IFTemperatureProfileLoad lusasBarDifferentialTemperatureLoad =
+                    CreateBarDifferentialTemperatureLoad(barDifferentialTemperatureLoad, assignedLines);
+
+                if (lusasBarDifferentialTemperatureLoad == null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        private bool CreateCollection(IEnumerable<AreaDifferentialTemperatureLoad> areaDifferentialTemperatureLoads)
+        {
+            foreach (AreaDifferentialTemperatureLoad areaDifferentialTemperatureLoad in areaDifferentialTemperatureLoads)
+            {
+                object[] assignedSurfaces = GetAssignedSurfaces(areaDifferentialTemperatureLoad);
+                IFTemperatureProfileLoad lusasAreaDifferentialTemperatureLoad =
+                    CreateAreaDifferentialTemperatureLoad(areaDifferentialTemperatureLoad, assignedSurfaces);
+
+                if (lusasAreaDifferentialTemperatureLoad == null)
                 {
                     return false;
                 }

--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -493,11 +493,6 @@ namespace BH.Adapter.Lusas
             foreach (Loadcase loadcase in loadcases)
             {
                 IFLoadcase lusasLoadcase = CreateLoadcase(loadcase);
-
-                if (lusasLoadcase == null)
-                {
-                    return false;
-                }
             }
 
             return true;
@@ -512,11 +507,6 @@ namespace BH.Adapter.Lusas
             {
                 object[] assignedPoints = GetAssignedPoints(PointLoad);
                 IFLoadingConcentrated lusasPointLoad = CreateConcentratedLoad(PointLoad, assignedPoints);
-
-                if (lusasPointLoad == null)
-                {
-                    return false;
-                }
             }
 
             return true;
@@ -530,11 +520,6 @@ namespace BH.Adapter.Lusas
             {
                 IFGeometry[] assignedGeometry = GetAssignedObjects(gravityLoad);
                 IFLoadingBody lusasGravityLoad = CreateGravityLoad(gravityLoad, assignedGeometry);
-
-                if (lusasGravityLoad == null)
-                {
-                    return false;
-                }
             }
 
             return true;
@@ -552,21 +537,11 @@ namespace BH.Adapter.Lusas
                 {
                     IFLoadingGlobalDistributed lusasGlobalDistributed =
                         CreateGlobalDistributedLine(barUniformlyDistributedLoad, assignedLines);
-
-                    if (lusasGlobalDistributed == null)
-                    {
-                        return false;
-                    }
                 }
                 else if (barUniformlyDistributedLoad.Axis == LoadAxis.Local)
                 {
                     IFLoadingLocalDistributed lusasLocalDistributed =
                         CreateLocalDistributedLine(barUniformlyDistributedLoad, assignedLines);
-
-                    if (lusasLocalDistributed == null)
-                    {
-                        return false;
-                    }
                 }
             }
 
@@ -584,21 +559,11 @@ namespace BH.Adapter.Lusas
                 {
                     IFLoadingGlobalDistributed lusasGlobalDistributed =
                         CreateGlobalDistributedLoadSurface(areaUniformlyDistributedLoad, assignedSurfaces);
-
-                    if (lusasGlobalDistributed == null)
-                    {
-                        return false;
-                    }
                 }
                 else if (areaUniformlyDistributedLoad.Axis == LoadAxis.Local)
                 {
                     IFLoadingLocalDistributed lusasLocalDistributed =
                         CreateLocalDistributedSurface(areaUniformlyDistributedLoad, assignedSurfaces);
-
-                    if (lusasLocalDistributed == null)
-                    {
-                        return false;
-                    }
                 }
             }
 
@@ -614,11 +579,6 @@ namespace BH.Adapter.Lusas
                 object[] arrayLines = GetAssignedLines(barUniformTemperatureLoad);
                 IFLoadingTemperature lusasBarUniformTemperatureLoad =
                     CreateBarUniformTemperatureLoad(barUniformTemperatureLoad, arrayLines);
-
-                if (lusasBarUniformTemperatureLoad == null)
-                {
-                    return false;
-                }
             }
 
             return true;
@@ -633,11 +593,6 @@ namespace BH.Adapter.Lusas
                 object[] assignedLines = GetAssignedSurfaces(areaUniformTemperatureLoad);
                 IFLoadingTemperature lusasAreaUniformTemperatureLoad =
                     CreateAreaUniformTemperatureLoad(areaUniformTemperatureLoad, assignedLines);
-
-                if (lusasAreaUniformTemperatureLoad == null)
-                {
-                    return false;
-                }
             }
 
             return true;
@@ -652,11 +607,6 @@ namespace BH.Adapter.Lusas
                 object[] assignedLines = GetAssignedLines(barDifferentialTemperatureLoad);
                 IFTemperatureProfileLoad lusasBarDifferentialTemperatureLoad =
                     CreateBarDifferentialTemperatureLoad(barDifferentialTemperatureLoad, assignedLines);
-
-                if (lusasBarDifferentialTemperatureLoad == null)
-                {
-                    return false;
-                }
             }
 
             return true;
@@ -671,11 +621,6 @@ namespace BH.Adapter.Lusas
                 object[] assignedSurfaces = GetAssignedSurfaces(areaDifferentialTemperatureLoad);
                 IFTemperatureProfileLoad lusasAreaDifferentialTemperatureLoad =
                     CreateAreaDifferentialTemperatureLoad(areaDifferentialTemperatureLoad, assignedSurfaces);
-
-                if (lusasAreaDifferentialTemperatureLoad == null)
-                {
-                    return false;
-                }
             }
 
             return true;
@@ -690,11 +635,6 @@ namespace BH.Adapter.Lusas
                 object[] assignedPoints = GetAssignedPoints(pointDisplacement);
                 IFPrescribedDisplacementLoad lusasPrescribedDisplacement =
                     CreatePrescribedDisplacement(pointDisplacement, assignedPoints);
-
-                if (lusasPrescribedDisplacement == null)
-                {
-                    return false;
-                }
             }
 
             return true;
@@ -711,10 +651,6 @@ namespace BH.Adapter.Lusas
                 IFLoadingBeamPoint lusasGlobalDistributed =
                     CreateBarPointLoad(barPointLoad, assignedLines);
 
-                if (lusasGlobalDistributed == null)
-                {
-                    return false;
-                }
             }
 
             return true;
@@ -745,10 +681,6 @@ namespace BH.Adapter.Lusas
                 if (constraint != null)
                 {
                     IFAttribute lusasSupport = CreateSupport(constraint);
-                    if (lusasSupport == null)
-                    {
-                        return false;
-                    }
                 }
             }
 
@@ -762,10 +694,6 @@ namespace BH.Adapter.Lusas
                 if (constraint != null)
                 {
                     IFAttribute lusasSupport = CreateSupport(constraint);
-                    if (lusasSupport == null)
-                    {
-                        return false;
-                    }
                 }
             }
 
@@ -777,11 +705,6 @@ namespace BH.Adapter.Lusas
             foreach (LoadCombination loadcombination in loadcombinations)
             {
                 IFBasicCombination lusasLoadCombination = CreateLoadCombination(loadcombination);
-
-                if (lusasLoadCombination == null)
-                {
-                    return false;
-                }
             }
 
             return true;

--- a/Lusas_Adapter/CRUD/Create/Create.cs
+++ b/Lusas_Adapter/CRUD/Create/Create.cs
@@ -327,7 +327,7 @@ namespace BH.Adapter.Lusas
 
                     foreach (MeshSettings2D mesh in distinctMeshes)
                     {
-                        if(mesh != null)
+                        if (mesh != null)
                             CreateMeshSettings2D(mesh);
                     }
 

--- a/Lusas_Adapter/CRUD/Create/Loads/DifferentialTemperatureLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/DifferentialTemperatureLoad.cs
@@ -65,8 +65,8 @@ namespace BH.Adapter.Lusas
 
             IFTemperatureProfileLoad lusasProfileLoad = CreateProfileTemperatureLoad(
                 temperatureLoad.Name, temperatureLoad.TemperatureProfile, loadDirection, lusasLines, assignedLoadcase);
-
-            temperatureLoad.SetAdapterId(typeof(LusasId), lusasProfileLoad.getID());
+            if (lusasProfileLoad != null)
+                temperatureLoad.SetAdapterId(typeof(LusasId), lusasProfileLoad.getID());
 
             return lusasProfileLoad;
         }
@@ -82,7 +82,8 @@ namespace BH.Adapter.Lusas
             IFTemperatureProfileLoad lusasProfileLoad = CreateProfileTemperatureLoad(
                 temperatureLoad.Name, temperatureLoad.TemperatureProfile, "local z", lusasSurfaces, assignedLoadcase);
 
-            temperatureLoad.SetAdapterId(typeof(LusasId), lusasProfileLoad.getID());
+            if (lusasProfileLoad != null)
+                temperatureLoad.SetAdapterId(typeof(LusasId), lusasProfileLoad.getID());
 
             return lusasProfileLoad;
         }

--- a/Lusas_Adapter/CRUD/Create/Loads/DifferentialTemperatureLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/DifferentialTemperatureLoad.cs
@@ -1,0 +1,144 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.Lusas;
+using BH.oM.Structure.Loads;
+using Lusas.LPI;
+
+namespace BH.Adapter.Lusas
+{
+#if Debug18 || Release18
+    public partial class LusasV18Adapter
+#elif Debug19 || Release19
+    public partial class LusasV19Adapter
+#elif Debug191 || Release191
+    public partial class LusasV191Adapter
+#elif Debug200 || Release200
+    public partial class LusasV200Adapter
+#elif Debug210 || Release210
+    public partial class LusasV210Adapter
+#elif Debug211 || Release211
+    public partial class LusasV211Adapter
+#elif Debug220 || Release220
+    public partial class LusasV220Adapter
+#elif Debug230 || Release230
+    public partial class LusasV230Adapter
+#else
+    public partial class LusasV17Adapter
+#endif
+    {
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private IFTemperatureProfileLoad CreateBarDifferentialTemperatureLoad(
+            BarDifferentialTemperatureLoad temperatureLoad, object[] lusasLines)
+        {
+            IFLoadcase assignedLoadcase = (IFLoadcase)d_LusasData.getLoadset(
+                temperatureLoad.Loadcase.AdapterId<int>(typeof(LusasId)));
+
+            string loadDirection = temperatureLoad.LoadDirection == DifferentialTemperatureLoadDirection.LocalY
+                ? "local y"
+                : "local z";
+
+            IFTemperatureProfileLoad lusasProfileLoad = CreateProfileTemperatureLoad(
+                temperatureLoad.Name, temperatureLoad.TemperatureProfile, loadDirection, lusasLines, assignedLoadcase);
+
+            temperatureLoad.SetAdapterId(typeof(LusasId), lusasProfileLoad.getID());
+
+            return lusasProfileLoad;
+        }
+
+        /***************************************************/
+
+        private IFTemperatureProfileLoad CreateAreaDifferentialTemperatureLoad(
+            AreaDifferentialTemperatureLoad temperatureLoad, object[] lusasSurfaces)
+        {
+            IFLoadcase assignedLoadcase = (IFLoadcase)d_LusasData.getLoadset(
+                temperatureLoad.Loadcase.AdapterId<int>(typeof(LusasId)));
+
+            IFTemperatureProfileLoad lusasProfileLoad = CreateProfileTemperatureLoad(
+                temperatureLoad.Name, temperatureLoad.TemperatureProfile, "local z", lusasSurfaces, assignedLoadcase);
+
+            temperatureLoad.SetAdapterId(typeof(LusasId), lusasProfileLoad.getID());
+
+            return lusasProfileLoad;
+        }
+
+        /***************************************************/
+
+        private IFTemperatureProfileLoad CreateProfileTemperatureLoad(string name,
+            Dictionary<double, double> temperatureProfile, string loadDirection,
+            object[] lusasGeometry, IFLoadcase assignedLoadcase)
+        {
+            IFTemperatureProfileLoad lusasProfileLoad;
+
+            if (d_LusasData.existsAttribute("Loading", name))
+            {
+                lusasProfileLoad = (IFTemperatureProfileLoad)d_LusasData.getAttributes("Loading", name);
+            }
+            else
+            {
+                lusasProfileLoad = d_LusasData.createLoadingTemperatureProfile(name);
+
+                List<KeyValuePair<double, double>> sortedProfile = temperatureProfile
+                    .OrderBy(kv => kv.Key)
+                    .ToList();
+
+                lusasProfileLoad.setTopTemperature(sortedProfile.Last().Value);
+                lusasProfileLoad.setForceType("Axial and Flexural");
+                lusasProfileLoad.setLoadDirection(loadDirection);
+                lusasProfileLoad.setAnalysisCategory("3D");
+
+                if (sortedProfile.Count == 2)
+                {
+                    // Simple linear gradient: only a top and bottom boundary, no intermediate rows needed.
+                    lusasProfileLoad.setBottomTemperature(sortedProfile.First().Value);
+                }
+                else
+                {
+                    // Multi-layer: define the full profile using only upper rows so that Lusas does not
+                    // generate a separate lower profile from setBottomTemperature. Rows span from the top
+                    // position (1) all the way down to position 0, covering every zone.
+                    for (int i = sortedProfile.Count - 2; i >= 0; i--)
+                    {
+                        double thickness = sortedProfile[i + 1].Key - sortedProfile[i].Key;
+                        double temperature = sortedProfile[i].Value;
+                        lusasProfileLoad.addUpperRow(thickness, temperature);
+                    }
+                }
+            }
+
+            IFAssignment lusasAssignment = m_LusasApplication.assignment();
+            lusasAssignment.setLoadset(assignedLoadcase);
+            lusasProfileLoad.assignTo(lusasGeometry, lusasAssignment);
+
+            return lusasProfileLoad;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Lusas_Adapter/CRUD/Create/Loads/DifferentialTemperatureLoad.cs
+++ b/Lusas_Adapter/CRUD/Create/Loads/DifferentialTemperatureLoad.cs
@@ -93,6 +93,16 @@ namespace BH.Adapter.Lusas
             Dictionary<double, double> temperatureProfile, string loadDirection,
             object[] lusasGeometry, IFLoadcase assignedLoadcase)
         {
+            if (temperatureProfile.Count > 2)
+            {
+                Engine.Base.Compute.RecordError(
+                    $"The TemperatureProfile for '{name}' contains {temperatureProfile.Count} positions. " +
+                    "Multi-layer differential temperature profiles are not currently supported in the Lusas_Toolkit " +
+                    "because BHoM uses normalised (parametric) positions whereas Lusas requires absolute thicknesses. " +
+                    "Only profiles with exactly two positions (bottom = 0 and top = 1) can be pushed.");
+                return null;
+            }
+
             IFTemperatureProfileLoad lusasProfileLoad;
 
             if (d_LusasData.existsAttribute("Loading", name))
@@ -101,34 +111,16 @@ namespace BH.Adapter.Lusas
             }
             else
             {
-                lusasProfileLoad = d_LusasData.createLoadingTemperatureProfile(name);
-
                 List<KeyValuePair<double, double>> sortedProfile = temperatureProfile
                     .OrderBy(kv => kv.Key)
                     .ToList();
 
+                lusasProfileLoad = d_LusasData.createLoadingTemperatureProfile(name);
                 lusasProfileLoad.setTopTemperature(sortedProfile.Last().Value);
+                lusasProfileLoad.setBottomTemperature(sortedProfile.First().Value);
                 lusasProfileLoad.setForceType("Axial and Flexural");
                 lusasProfileLoad.setLoadDirection(loadDirection);
                 lusasProfileLoad.setAnalysisCategory("3D");
-
-                if (sortedProfile.Count == 2)
-                {
-                    // Simple linear gradient: only a top and bottom boundary, no intermediate rows needed.
-                    lusasProfileLoad.setBottomTemperature(sortedProfile.First().Value);
-                }
-                else
-                {
-                    // Multi-layer: define the full profile using only upper rows so that Lusas does not
-                    // generate a separate lower profile from setBottomTemperature. Rows span from the top
-                    // position (1) all the way down to position 0, covering every zone.
-                    for (int i = sortedProfile.Count - 2; i >= 0; i--)
-                    {
-                        double thickness = sortedProfile[i + 1].Key - sortedProfile[i].Key;
-                        double temperature = sortedProfile[i].Value;
-                        lusasProfileLoad.addUpperRow(thickness, temperature);
-                    }
-                }
             }
 
             IFAssignment lusasAssignment = m_LusasApplication.assignment();

--- a/Lusas_Adapter/CRUD/Read/Loads/AreaDifferentialTemperatureLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/AreaDifferentialTemperatureLoads.cs
@@ -20,9 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
 using System.Collections.Generic;
+using System.Linq;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.Lusas;
+using BH.oM.Structure.Elements;
 using BH.oM.Structure.Loads;
+using Lusas.LPI;
 
 namespace BH.Adapter.Lusas
 {
@@ -50,61 +54,54 @@ namespace BH.Adapter.Lusas
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private List<ILoad> ChooseLoad(Type type, List<string> ids = null)
+        private List<ILoad> ReadAreaDifferentialTemperatureLoads(List<string> ids = null)
         {
-            List<ILoad> readLoads = new List<ILoad>();
-            string typeName = type.Name;
-            switch (typeName)
+            List<ILoad> areaDifferentialTemperatureLoads = new List<ILoad>();
+            object[] lusasProfileLoads = d_LusasData.getAttributes("Profile Temperature Load");
+
+            if (lusasProfileLoads.Count() == 0)
+                return areaDifferentialTemperatureLoads;
+
+            List<Panel> panelsList = GetCachedOrRead<Panel>();
+            Dictionary<string, Panel> panels = panelsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
+
+            for (int i = 0; i < lusasProfileLoads.Count(); i++)
             {
-                case "PointLoad":
-                    readLoads = ReadPointLoads(ids as dynamic);
-                    break;
-                case "GravityLoad":
-                    readLoads = ReadGravityLoads(ids as dynamic);
-                    break;
-                case "BarUniformlyDistributedLoad":
-                    readLoads = ReadBarUniformlyDistributedLoads(ids as dynamic);
-                    break;
-                case "AreaUniformlyDistributedLoad":
-                    readLoads = ReadAreaUniformlyDistributedLoads(ids as dynamic);
-                    break;
-                case "BarUniformTemperatureLoad":
-                    readLoads = ReadBarUniformTemperatureLoads(ids as dynamic);
-                    break;
-                case "AreaUniformTemperatureLoad":
-                    readLoads = ReadAreaUniformTemperatureLoads(ids as dynamic);
-                    break;
-                case "BarDifferentialTemperatureLoad":
-                    readLoads = ReadBarDifferentialTemperatureLoads(ids as dynamic);
-                    break;
-                case "AreaDifferentialTemperatureLoad":
-                    readLoads = ReadAreaDifferentialTemperatureLoads(ids as dynamic);
-                    break;
-                case "PointDisplacement":
-                    readLoads = ReadPointDisplacements(ids as dynamic);
-                    break;
-                case "BarPointLoad":
-                    readLoads = ReadBarPointLoads(ids as dynamic);
-                    break;
-                case "BarVaryingDistributedLoad":
-                    readLoads = ReadBarVaryingDistributedLoads(ids as dynamic);
-                    break;
-                default:
-                    Engine.Base.Compute.RecordError($"{type} is not supported in the Lusas_Toolkit.");
-                    break;
+                IFLoading lusasProfileLoad = (IFLoading)lusasProfileLoads[i];
+
+                IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
+                    GetLoadAssignments(lusasProfileLoad);
+
+                foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                {
+                    List<IFAssignment> surfaceAssignments = new List<IFAssignment>();
+
+                    foreach (IFAssignment assignment in groupedAssignment)
+                    {
+                        IFSurface trySurf = assignment.getDatabaseObject() as IFSurface;
+
+                        if (trySurf != null)
+                            surfaceAssignments.Add(assignment);
+                    }
+
+                    if (surfaceAssignments.Count == 0)
+                        continue;
+
+                    List<string> analysisName = new List<string> { lusasProfileLoad.getAttributeType() };
+
+                    AreaDifferentialTemperatureLoad areaDifferentialTemperatureLoad =
+                        Adapter.Adapters.Lusas.Convert.ToAreaDifferentialTemperatureLoad(
+                            lusasProfileLoad, groupedAssignment, panels);
+
+                    areaDifferentialTemperatureLoad.Tags = new HashSet<string>(analysisName);
+                    areaDifferentialTemperatureLoads.Add(areaDifferentialTemperatureLoad);
+                }
             }
 
-            return readLoads;
+            return areaDifferentialTemperatureLoads;
         }
 
         /***************************************************/
 
     }
 }
-
-
-
-
-
-
-

--- a/Lusas_Adapter/CRUD/Read/Loads/BarDifferentialTemperatureLoads.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/BarDifferentialTemperatureLoads.cs
@@ -20,9 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
 using System.Collections.Generic;
+using System.Linq;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.Lusas;
+using BH.oM.Structure.Elements;
 using BH.oM.Structure.Loads;
+using Lusas.LPI;
 
 namespace BH.Adapter.Lusas
 {
@@ -50,61 +54,54 @@ namespace BH.Adapter.Lusas
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private List<ILoad> ChooseLoad(Type type, List<string> ids = null)
+        private List<ILoad> ReadBarDifferentialTemperatureLoads(List<string> ids = null)
         {
-            List<ILoad> readLoads = new List<ILoad>();
-            string typeName = type.Name;
-            switch (typeName)
+            List<ILoad> barDifferentialTemperatureLoads = new List<ILoad>();
+            object[] lusasProfileLoads = d_LusasData.getAttributes("Profile Temperature Load");
+
+            if (lusasProfileLoads.Count() == 0)
+                return barDifferentialTemperatureLoads;
+
+            List<Bar> barsList = GetCachedOrRead<Bar>();
+            Dictionary<string, Bar> bars = barsList.ToDictionary(x => x.AdapterId<string>(typeof(LusasId)));
+
+            for (int i = 0; i < lusasProfileLoads.Count(); i++)
             {
-                case "PointLoad":
-                    readLoads = ReadPointLoads(ids as dynamic);
-                    break;
-                case "GravityLoad":
-                    readLoads = ReadGravityLoads(ids as dynamic);
-                    break;
-                case "BarUniformlyDistributedLoad":
-                    readLoads = ReadBarUniformlyDistributedLoads(ids as dynamic);
-                    break;
-                case "AreaUniformlyDistributedLoad":
-                    readLoads = ReadAreaUniformlyDistributedLoads(ids as dynamic);
-                    break;
-                case "BarUniformTemperatureLoad":
-                    readLoads = ReadBarUniformTemperatureLoads(ids as dynamic);
-                    break;
-                case "AreaUniformTemperatureLoad":
-                    readLoads = ReadAreaUniformTemperatureLoads(ids as dynamic);
-                    break;
-                case "BarDifferentialTemperatureLoad":
-                    readLoads = ReadBarDifferentialTemperatureLoads(ids as dynamic);
-                    break;
-                case "AreaDifferentialTemperatureLoad":
-                    readLoads = ReadAreaDifferentialTemperatureLoads(ids as dynamic);
-                    break;
-                case "PointDisplacement":
-                    readLoads = ReadPointDisplacements(ids as dynamic);
-                    break;
-                case "BarPointLoad":
-                    readLoads = ReadBarPointLoads(ids as dynamic);
-                    break;
-                case "BarVaryingDistributedLoad":
-                    readLoads = ReadBarVaryingDistributedLoads(ids as dynamic);
-                    break;
-                default:
-                    Engine.Base.Compute.RecordError($"{type} is not supported in the Lusas_Toolkit.");
-                    break;
+                IFLoading lusasProfileLoad = (IFLoading)lusasProfileLoads[i];
+
+                IEnumerable<IGrouping<string, IFAssignment>> groupedByLoadcases =
+                    GetLoadAssignments(lusasProfileLoad);
+
+                foreach (IEnumerable<IFAssignment> groupedAssignment in groupedByLoadcases)
+                {
+                    List<IFAssignment> lineAssignments = new List<IFAssignment>();
+
+                    foreach (IFAssignment assignment in groupedAssignment)
+                    {
+                        IFLine tryLine = assignment.getDatabaseObject() as IFLine;
+
+                        if (tryLine != null)
+                            lineAssignments.Add(assignment);
+                    }
+
+                    if (lineAssignments.Count == 0)
+                        continue;
+
+                    List<string> analysisName = new List<string> { lusasProfileLoad.getAttributeType() };
+
+                    BarDifferentialTemperatureLoad barDifferentialTemperatureLoad =
+                        Adapter.Adapters.Lusas.Convert.ToBarDifferentialTemperatureLoad(
+                            lusasProfileLoad, groupedAssignment, bars);
+
+                    barDifferentialTemperatureLoad.Tags = new HashSet<string>(analysisName);
+                    barDifferentialTemperatureLoads.Add(barDifferentialTemperatureLoad);
+                }
             }
 
-            return readLoads;
+            return barDifferentialTemperatureLoads;
         }
 
         /***************************************************/
 
     }
 }
-
-
-
-
-
-
-

--- a/Lusas_Adapter/CRUD/Read/ReadAll.cs
+++ b/Lusas_Adapter/CRUD/Read/ReadAll.cs
@@ -66,6 +66,8 @@ namespace BH.Adapter.Lusas
             objects.AddRange(ReadAreaUniformlyDistributedLoads());
             objects.AddRange(ReadBarUniformTemperatureLoads());
             objects.AddRange(ReadAreaUniformTemperatureLoads());
+            objects.AddRange(ReadBarDifferentialTemperatureLoads());
+            objects.AddRange(ReadAreaDifferentialTemperatureLoads());
             objects.AddRange(ReadGravityLoads());
             return objects;
         }

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ExtractTemperatureProfile.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ExtractTemperatureProfile.cs
@@ -20,7 +20,6 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
 using System.Collections.Generic;
 using Lusas.LPI;
 
@@ -32,47 +31,19 @@ namespace BH.Adapter.Adapters.Lusas
         /**** Public Methods                            ****/
         /***************************************************/
 
-        // NOTE: The field names "TTop", "TBot", "thickness", and "temperature" are the Lusas LPI
-        // internal parameter names for IFTemperatureProfileLoad. These should be verified against
-        // the Lusas LPI documentation or confirmed via getValue inspection during integration testing.
+        // NOTE: The field names "TTop" and "TBot" are the Lusas LPI internal parameter names for
+        // IFTemperatureProfileLoad. These should be verified against the Lusas LPI documentation
+        // or confirmed via getValue inspection during integration testing.
         public static Dictionary<double, double> ExtractTemperatureProfile(IFTemperatureProfileLoad profileLoad)
         {
             double topTemperature = (double)profileLoad.getValue("TTop");
-            long rowCount = profileLoad.countRows("thickness");
+            double bottomTemperature = (double)profileLoad.getValue("TBot");
 
-            if (rowCount == 0)
+            return new Dictionary<double, double>
             {
-                // Simple linear profile defined by top and bottom boundary temperatures only.
-                double bottomTemperature = (double)profileLoad.getValue("TBot");
-                return new Dictionary<double, double>
-                {
-                    { 0.0, bottomTemperature },
-                    { 1.0, topTemperature }
-                };
-            }
-
-            // Multi-layer profile defined entirely by upper rows. Reconstruct normalised positions
-            // by subtracting each row's fractional thickness from the top (position 1) downward.
-            Dictionary<double, double> profile = new Dictionary<double, double>
-            {
+                { 0.0, bottomTemperature },
                 { 1.0, topTemperature }
             };
-
-            double cumulativePosition = 1.0;
-#if Debug220 || Release220 || Debug230 || Release230
-                for (long i = 0; i < rowCount; i++)
-
-#else
-            for (int i = 0; i < rowCount; i++)
-#endif
-            {
-                double thickness = (double)profileLoad.getRowValue("thickness", i, Type.Missing);
-                double temperature = (double)profileLoad.getRowValue("temperature", i, Type.Missing);
-                cumulativePosition -= thickness;
-                profile[Math.Round(cumulativePosition, 10)] = temperature;
-            }
-
-            return profile;
         }
 
         /***************************************************/

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ExtractTemperatureProfile.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ExtractTemperatureProfile.cs
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using Lusas.LPI;
+
+namespace BH.Adapter.Adapters.Lusas
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        // NOTE: The field names "TTop", "TBot", "thickness", and "temperature" are the Lusas LPI
+        // internal parameter names for IFTemperatureProfileLoad. These should be verified against
+        // the Lusas LPI documentation or confirmed via getValue inspection during integration testing.
+        public static Dictionary<double, double> ExtractTemperatureProfile(IFTemperatureProfileLoad profileLoad)
+        {
+            double topTemperature = (double)profileLoad.getValue("TTop");
+            long rowCount = profileLoad.countRows("thickness");
+
+            if (rowCount == 0)
+            {
+                // Simple linear profile defined by top and bottom boundary temperatures only.
+                double bottomTemperature = (double)profileLoad.getValue("TBot");
+                return new Dictionary<double, double>
+                {
+                    { 0.0, bottomTemperature },
+                    { 1.0, topTemperature }
+                };
+            }
+
+            // Multi-layer profile defined entirely by upper rows. Reconstruct normalised positions
+            // by subtracting each row's fractional thickness from the top (position 1) downward.
+            Dictionary<double, double> profile = new Dictionary<double, double>
+            {
+                { 1.0, topTemperature }
+            };
+
+            double cumulativePosition = 1.0;
+#if Debug220 || Release220 || Debug230 || Release230
+                for (long i = 0; i < rowCount; i++)
+
+#else
+            for (int i = 0; i < rowCount; i++)
+#endif
+            {
+                double thickness = (double)profileLoad.getRowValue("thickness", i, Type.Missing);
+                double temperature = (double)profileLoad.getRowValue("temperature", i, Type.Missing);
+                cumulativePosition -= thickness;
+                profile[Math.Round(cumulativePosition, 10)] = temperature;
+            }
+
+            return profile;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToAreaDifferentialTemperatureLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToAreaDifferentialTemperatureLoad.cs
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.Lusas;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Loads;
+using Lusas.LPI;
+
+namespace BH.Adapter.Adapters.Lusas
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static AreaDifferentialTemperatureLoad ToAreaDifferentialTemperatureLoad(
+            IFLoading lusasProfileLoad,
+            IEnumerable<IFAssignment> lusasAssignments,
+            Dictionary<string, Panel> panels)
+        {
+            IFTemperatureProfileLoad profileLoad = (IFTemperatureProfileLoad)lusasProfileLoad;
+
+            IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
+            Loadcase loadcase = ToLoadcase(assignedLoadcase);
+
+            Dictionary<double, double> temperatureProfile = ExtractTemperatureProfile(profileLoad);
+
+            IEnumerable<IAreaElement> assignedPanels = GetSurfaceAssignments(lusasAssignments, panels);
+
+            AreaDifferentialTemperatureLoad areaDifferentialTemperatureLoad = new AreaDifferentialTemperatureLoad
+            {
+                Loadcase = loadcase,
+                TemperatureProfile = temperatureProfile,
+                Objects = new BH.oM.Base.BHoMGroup<IAreaElement> { Elements = assignedPanels.ToList() },
+                Name = GetName(lusasProfileLoad)
+            };
+
+            long adapterNameId = lusasProfileLoad.getID();
+            areaDifferentialTemperatureLoad.SetAdapterId(typeof(LusasId), adapterNameId);
+
+            return areaDifferentialTemperatureLoad;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDifferentialTemperatureLoad.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ToBarDifferentialTemperatureLoad.cs
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.Lusas;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Loads;
+using Lusas.LPI;
+
+namespace BH.Adapter.Adapters.Lusas
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static BarDifferentialTemperatureLoad ToBarDifferentialTemperatureLoad(
+            IFLoading lusasProfileLoad,
+            IEnumerable<IFAssignment> lusasAssignments,
+            Dictionary<string, Bar> bars)
+        {
+            IFTemperatureProfileLoad profileLoad = (IFTemperatureProfileLoad)lusasProfileLoad;
+
+            IFLoadcase assignedLoadcase = (IFLoadcase)lusasAssignments.First().getAssignmentLoadset();
+            Loadcase loadcase = ToLoadcase(assignedLoadcase);
+
+            Dictionary<double, double> temperatureProfile = ExtractTemperatureProfile(profileLoad);
+
+            string loadDirectionString = (string)profileLoad.getValue("LoadDir");
+            DifferentialTemperatureLoadDirection loadDirection = loadDirectionString == "local y"
+                ? DifferentialTemperatureLoadDirection.LocalY
+                : DifferentialTemperatureLoadDirection.LocalZ;
+
+            IEnumerable<Bar> assignedBars = GetLineAssignments(lusasAssignments, bars);
+
+            BarDifferentialTemperatureLoad barDifferentialTemperatureLoad =
+                Engine.Structure.Create.BarDifferentialTemperatureLoad(
+                    loadcase,
+                    temperatureProfile.Keys.ToList(),
+                    temperatureProfile.Values.ToList(),
+                    loadDirection,
+                    assignedBars,
+                    GetName(lusasProfileLoad));
+
+            long adapterNameId = lusasProfileLoad.getID();
+            barDifferentialTemperatureLoad.SetAdapterId(typeof(LusasId), adapterNameId);
+
+            return barDifferentialTemperatureLoad;
+        }
+
+        /***************************************************/
+
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #451 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Lusas_Toolkit/%23452-AddSupportForBarDifferentialTemperatureAndArea?csf=1&web=1&e=lWh193

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added support for push/pull `BarDifferentialLoad`;
- Added support for push/pull `AreaDifferentialLod`;
- Note that both use the same `IFProfileTemperartureLoad` object in Lusas. Given that Lusas uses absolute distances and the BHoM objects use parametric distances - only profiles that have top/bottom temperatures are supported for now.

### Additional comments
<!-- As required -->