### PR TITLE
Remove read support differential temperature loads

### DIFF
--- a/Lusas_Adapter/CRUD/Read/Loads/ChooseLoad.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/ChooseLoad.cs
@@ -74,12 +74,6 @@ namespace BH.Adapter.Lusas
                 case "AreaUniformTemperatureLoad":
                     readLoads = ReadAreaUniformTemperatureLoads(ids as dynamic);
                     break;
-                case "BarDifferentialTemperatureLoad":
-                    readLoads = ReadBarDifferentialTemperatureLoads(ids as dynamic);
-                    break;
-                case "AreaDifferentialTemperatureLoad":
-                    readLoads = ReadAreaDifferentialTemperatureLoads(ids as dynamic);
-                    break;
                 case "PointDisplacement":
                     readLoads = ReadPointDisplacements(ids as dynamic);
                     break;
@@ -90,7 +84,7 @@ namespace BH.Adapter.Lusas
                     readLoads = ReadBarVaryingDistributedLoads(ids as dynamic);
                     break;
                 default:
-                    Engine.Base.Compute.RecordError($"{type} is not supported in the Lusas_Toolkit.");
+                    Engine.Base.Compute.RecordError($"{type} pulling is not supported in the Lusas_Toolkit.");
                     break;
             }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #456 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Can be by inspection to allow for testing in installer tomorrow;
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Lusas_Toolkit/%23452-AddSupportForBarDifferentialTemperatureAndArea?csf=1&web=1&e=lWh193

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Removed read support for `BarDifferentialTemperatureLoad` and `AreaDifferentialTemperatureLoad`.

### Additional comments
<!-- As required -->