### PR TITLE
Reinstate read functionality for different loads

### DIFF
--- a/Lusas_Adapter/CRUD/Read/Loads/ChooseLoad.cs
+++ b/Lusas_Adapter/CRUD/Read/Loads/ChooseLoad.cs
@@ -83,6 +83,12 @@ namespace BH.Adapter.Lusas
                 case "BarVaryingDistributedLoad":
                     readLoads = ReadBarVaryingDistributedLoads(ids as dynamic);
                     break;
+                case "BarDifferentialTemperatureLoad":
+                    readLoads = ReadBarDifferentialTemperatureLoads(ids as dynamic);
+                    break;
+                case "AreaDifferentialTemperatureLoad":
+                    readLoads = ReadAreaDifferentialTemperatureLoads(ids as dynamic);
+                    break;
                 default:
                     Engine.Base.Compute.RecordError($"{type} pulling is not supported in the Lusas_Toolkit.");
                     break;

--- a/Lusas_Adapter/Convert/ToBHoM/Loads/ExtractTemperatureProfile.cs
+++ b/Lusas_Adapter/Convert/ToBHoM/Loads/ExtractTemperatureProfile.cs
@@ -31,13 +31,10 @@ namespace BH.Adapter.Adapters.Lusas
         /**** Public Methods                            ****/
         /***************************************************/
 
-        // NOTE: The field names "TTop" and "TBot" are the Lusas LPI internal parameter names for
-        // IFTemperatureProfileLoad. These should be verified against the Lusas LPI documentation
-        // or confirmed via getValue inspection during integration testing.
         public static Dictionary<double, double> ExtractTemperatureProfile(IFTemperatureProfileLoad profileLoad)
         {
-            double topTemperature = (double)profileLoad.getValue("TTop");
-            double bottomTemperature = (double)profileLoad.getValue("TBot");
+            double topTemperature = double.Parse(profileLoad.getValue("topTemp"));
+            double bottomTemperature = double.Parse(profileLoad.getValue("bottomTemp"));
 
             return new Dictionary<double, double>
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #459 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Lusas_Toolkit/%23461-ReinstateRetrievalOfTempProfiles?csf=1&web=1&e=urCN1h

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added read functionality for `AreaDifferentialTemperatureLoad`;
- Added read functionality for `BarDifferentialTemperatureLoad`.

### Additional comments
<!-- As required -->